### PR TITLE
feat(popup): ruleset import and export

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
     "name": "dan-lovelace",
     "url": "https://github.com/dan-lovelace/word-replacer-max"
   },
-  "version": "0.0.3",
+  "version": "0.1.0",
   "license": "MIT",
   "description": "A browser extension for replacing text on web pages",
   "type": "module",

--- a/packages/content/public/assets/img/firefox-logo.svg
+++ b/packages/content/public/assets/img/firefox-logo.svg
@@ -1,0 +1,120 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- This Source Code Form is subject to the terms of the Mozilla Public
+   - License, v. 2.0. If a copy of the MPL was not distributed with this
+   - file, You can obtain one at http://mozilla.org/MPL/2.0/. -->
+<svg width="20" height="20.656" version="1.1" viewBox="0 0 77.42 79.97" xmlns="http://www.w3.org/2000/svg" xmlns:cc="http://creativecommons.org/ns#" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+ <title>Firefox Browser logo</title>
+ <defs>
+  <linearGradient id="a" x1="70.79" x2="6.447" y1="12.39" y2="74.47" gradientTransform="translate(-1.3 -.004086)" gradientUnits="userSpaceOnUse">
+   <stop stop-color="#fff44f" offset=".048"/>
+   <stop stop-color="#ffe847" offset=".111"/>
+   <stop stop-color="#ffc830" offset=".225"/>
+   <stop stop-color="#ff980e" offset=".368"/>
+   <stop stop-color="#ff8b16" offset=".401"/>
+   <stop stop-color="#ff672a" offset=".462"/>
+   <stop stop-color="#ff3647" offset=".534"/>
+   <stop stop-color="#e31587" offset=".705"/>
+  </linearGradient>
+  <radialGradient id="b" cx="-7907" cy="-8515" r="80.8" gradientTransform="translate(7974,8524)" gradientUnits="userSpaceOnUse">
+   <stop stop-color="#ffbd4f" offset=".129"/>
+   <stop stop-color="#ffac31" offset=".186"/>
+   <stop stop-color="#ff9d17" offset=".247"/>
+   <stop stop-color="#ff980e" offset=".283"/>
+   <stop stop-color="#ff563b" offset=".403"/>
+   <stop stop-color="#ff3750" offset=".467"/>
+   <stop stop-color="#f5156c" offset=".71"/>
+   <stop stop-color="#eb0878" offset=".782"/>
+   <stop stop-color="#e50080" offset=".86"/>
+  </radialGradient>
+  <radialGradient id="c" cx="-7937" cy="-8482" r="80.8" gradientTransform="translate(7974,8524)" gradientUnits="userSpaceOnUse">
+   <stop stop-color="#960e18" offset=".3"/>
+   <stop stop-color="#b11927" stop-opacity=".74" offset=".351"/>
+   <stop stop-color="#db293d" stop-opacity=".343" offset=".435"/>
+   <stop stop-color="#f5334b" stop-opacity=".094" offset=".497"/>
+   <stop stop-color="#ff3750" stop-opacity="0" offset=".53"/>
+  </radialGradient>
+  <radialGradient id="d" cx="-7927" cy="-8533" r="58.53" gradientTransform="translate(7974,8524)" gradientUnits="userSpaceOnUse">
+   <stop stop-color="#fff44f" offset=".132"/>
+   <stop stop-color="#ffdc3e" offset=".252"/>
+   <stop stop-color="#ff9d12" offset=".506"/>
+   <stop stop-color="#ff980e" offset=".526"/>
+  </radialGradient>
+  <radialGradient id="e" cx="-7946" cy="-8461" r="38.47" gradientTransform="translate(7974,8524)" gradientUnits="userSpaceOnUse">
+   <stop stop-color="#3a8ee6" offset=".353"/>
+   <stop stop-color="#5c79f0" offset=".472"/>
+   <stop stop-color="#9059ff" offset=".669"/>
+   <stop stop-color="#c139e6" offset="1"/>
+  </radialGradient>
+  <radialGradient id="f" cx="-7936" cy="-8492" r="20.4" gradientTransform="matrix(.972 -.235 .275 1.138 10090 7834)" gradientUnits="userSpaceOnUse">
+   <stop stop-color="#9059ff" stop-opacity="0" offset=".206"/>
+   <stop stop-color="#8c4ff3" stop-opacity=".064" offset=".278"/>
+   <stop stop-color="#7716a8" stop-opacity=".45" offset=".747"/>
+   <stop stop-color="#6e008b" stop-opacity=".6" offset=".975"/>
+  </radialGradient>
+  <radialGradient id="g" cx="-7938" cy="-8518" r="27.68" gradientTransform="translate(7974,8524)" gradientUnits="userSpaceOnUse">
+   <stop stop-color="#ffe226" offset="0"/>
+   <stop stop-color="#ffdb27" offset=".121"/>
+   <stop stop-color="#ffc82a" offset=".295"/>
+   <stop stop-color="#ffa930" offset=".502"/>
+   <stop stop-color="#ff7e37" offset=".732"/>
+   <stop stop-color="#ff7139" offset=".792"/>
+  </radialGradient>
+  <radialGradient id="h" cx="-7916" cy="-8536" r="118.1" gradientTransform="translate(7974,8524)" gradientUnits="userSpaceOnUse">
+   <stop stop-color="#fff44f" offset=".113"/>
+   <stop stop-color="#ff980e" offset=".456"/>
+   <stop stop-color="#ff5634" offset=".622"/>
+   <stop stop-color="#ff3647" offset=".716"/>
+   <stop stop-color="#e31587" offset=".904"/>
+  </radialGradient>
+  <radialGradient id="i" cx="-7927" cy="-8523" r="86.5" gradientTransform="matrix(.105 .995 -.653 .069 -4685 8470)" gradientUnits="userSpaceOnUse">
+   <stop stop-color="#fff44f" offset="0"/>
+   <stop stop-color="#ffe847" offset=".06"/>
+   <stop stop-color="#ffc830" offset=".168"/>
+   <stop stop-color="#ff980e" offset=".304"/>
+   <stop stop-color="#ff8b16" offset=".356"/>
+   <stop stop-color="#ff672a" offset=".455"/>
+   <stop stop-color="#ff3647" offset=".57"/>
+   <stop stop-color="#e31587" offset=".737"/>
+  </radialGradient>
+  <radialGradient id="j" cx="-7938" cy="-8508" r="73.72" gradientTransform="translate(7974,8524)" gradientUnits="userSpaceOnUse">
+   <stop stop-color="#fff44f" offset=".137"/>
+   <stop stop-color="#ff980e" offset=".48"/>
+   <stop stop-color="#ff5634" offset=".592"/>
+   <stop stop-color="#ff3647" offset=".655"/>
+   <stop stop-color="#e31587" offset=".904"/>
+  </radialGradient>
+  <radialGradient id="k" cx="-7919" cy="-8504" r="80.69" gradientTransform="translate(7974,8524)" gradientUnits="userSpaceOnUse">
+   <stop stop-color="#fff44f" offset=".094"/>
+   <stop stop-color="#ffe141" offset=".231"/>
+   <stop stop-color="#ffaf1e" offset=".509"/>
+   <stop stop-color="#ff980e" offset=".626"/>
+  </radialGradient>
+  <linearGradient id="l" x1="70.01" x2="15.27" y1="12.06" y2="66.81" gradientTransform="translate(-1.3 -.004086)" gradientUnits="userSpaceOnUse">
+   <stop stop-color="#fff44f" stop-opacity=".8" offset=".167"/>
+   <stop stop-color="#fff44f" stop-opacity=".634" offset=".266"/>
+   <stop stop-color="#fff44f" stop-opacity=".217" offset=".489"/>
+   <stop stop-color="#fff44f" stop-opacity="0" offset=".6"/>
+  </linearGradient>
+ </defs>
+ <g transform="matrix(.9819843 0 0 .9819843 .6974849 .7199239)">
+  <path d="m74.62 26.83c-1.684-4.052-5.1-8.427-7.775-9.81a40.27 40.27 0 0 1 3.925 11.76l7e-3 0.065c-4.382-10.92-11.81-15.33-17.88-24.92-0.307-0.485-0.614-0.971-0.913-1.484-0.171-0.293-0.308-0.557-0.427-0.8a7.053 7.053 0 0 1-0.578-1.535 0.1 0.1 0 0 0-0.088-0.1 0.138 0.138 0 0 0-0.073 0c-5e-3 0-0.013 9e-3 -0.019 0.011s-0.019 0.011-0.028 0.015l0.015-0.026c-9.735 5.7-13.04 16.25-13.34 21.53a19.39 19.39 0 0 0-10.67 4.111 11.59 11.59 0 0 0-1-0.758 17.97 17.97 0 0 1-0.109-9.473 28.7 28.7 0 0 0-9.329 7.21h-0.018c-1.536-1.947-1.428-8.367-1.34-9.708a6.928 6.928 0 0 0-1.294 0.687 28.22 28.22 0 0 0-3.788 3.245 33.84 33.84 0 0 0-3.623 4.347v6e-3 -7e-3a32.73 32.73 0 0 0-5.2 11.74l-0.052 0.256c-0.073 0.341-0.336 2.049-0.381 2.42 0 0.029-6e-3 0.056-9e-3 0.085a36.94 36.94 0 0 0-0.629 5.343v0.2a38.76 38.76 0 0 0 76.95 6.554c0.065-0.5 0.118-0.995 0.176-1.5a39.86 39.86 0 0 0-2.514-19.47zm-44.67 30.34c0.181 0.087 0.351 0.181 0.537 0.264l0.027 0.017q-0.282-0.135-0.564-0.281zm8.878-23.38m31.95-4.934v-0.037l7e-3 0.041z" fill="url(#a)"/>
+  <path d="m74.62 26.83c-1.684-4.052-5.1-8.427-7.775-9.81a40.27 40.27 0 0 1 3.925 11.76v0.037l7e-3 0.041a35.1 35.1 0 0 1-1.206 26.16c-4.442 9.531-15.19 19.3-32.02 18.82-18.18-0.515-34.2-14.01-37.19-31.68-0.545-2.787 0-4.2 0.274-6.465a28.88 28.88 0 0 0-0.623 5.348v0.2a38.76 38.76 0 0 0 76.95 6.554c0.065-0.5 0.118-0.995 0.176-1.5a39.86 39.86 0 0 0-2.514-19.47z" fill="url(#b)"/>
+  <path d="m74.62 26.83c-1.684-4.052-5.1-8.427-7.775-9.81a40.27 40.27 0 0 1 3.925 11.76v0.037l7e-3 0.041a35.1 35.1 0 0 1-1.206 26.16c-4.442 9.531-15.19 19.3-32.02 18.82-18.18-0.515-34.2-14.01-37.19-31.68-0.545-2.787 0-4.2 0.274-6.465a28.88 28.88 0 0 0-0.623 5.348v0.2a38.76 38.76 0 0 0 76.95 6.554c0.065-0.5 0.118-0.995 0.176-1.5a39.86 39.86 0 0 0-2.514-19.47z" fill="url(#c)"/>
+  <path d="m55.78 31.38c0.084 0.059 0.162 0.118 0.241 0.177a21.1 21.1 0 0 0-3.6-4.695c-12.05-12.05-3.157-26.12-1.658-26.84l0.015-0.022c-9.735 5.7-13.04 16.25-13.34 21.53 0.452-0.031 0.9-0.069 1.362-0.069a19.56 19.56 0 0 1 16.98 9.917z" fill="url(#d)"/>
+  <path d="m38.82 33.79c-0.064 0.964-3.47 4.289-4.661 4.289-11.02 0-12.81 6.667-12.81 6.667 0.488 5.614 4.4 10.24 9.129 12.68 0.216 0.112 0.435 0.213 0.654 0.312q0.569 0.252 1.138 0.466a17.24 17.24 0 0 0 5.043 0.973c19.32 0.906 23.06-23.1 9.119-30.07a13.38 13.38 0 0 1 9.345 2.269 19.56 19.56 0 0 0-16.98-9.917c-0.46 0-0.91 0.038-1.362 0.069a19.39 19.39 0 0 0-10.67 4.111c0.591 0.5 1.258 1.168 2.663 2.553 2.63 2.591 9.375 5.275 9.39 5.59z" fill="url(#e)"/>
+  <path d="m38.82 33.79c-0.064 0.964-3.47 4.289-4.661 4.289-11.02 0-12.81 6.667-12.81 6.667 0.488 5.614 4.4 10.24 9.129 12.68 0.216 0.112 0.435 0.213 0.654 0.312q0.569 0.252 1.138 0.466a17.24 17.24 0 0 0 5.043 0.973c19.32 0.906 23.06-23.1 9.119-30.07a13.38 13.38 0 0 1 9.345 2.269 19.56 19.56 0 0 0-16.98-9.917c-0.46 0-0.91 0.038-1.362 0.069a19.39 19.39 0 0 0-10.67 4.111c0.591 0.5 1.258 1.168 2.663 2.553 2.63 2.591 9.375 5.275 9.39 5.59z" fill="url(#f)"/>
+  <path d="m24.96 24.36c0.314 0.2 0.573 0.374 0.8 0.531a17.97 17.97 0 0 1-0.109-9.473 28.7 28.7 0 0 0-9.329 7.21c0.189-5e-3 5.811-0.106 8.638 1.732z" fill="url(#g)"/>
+  <path d="m0.354 42.16c2.991 17.67 19.01 31.17 37.19 31.68 16.83 0.476 27.58-9.294 32.02-18.82a35.1 35.1 0 0 0 1.206-26.16v-0.037c0-0.029-6e-3 -0.046 0-0.037l7e-3 0.065c1.375 8.977-3.191 17.67-10.33 23.56l-0.022 0.05c-13.91 11.33-27.22 6.834-29.91 5q-0.282-0.135-0.564-0.281c-8.109-3.876-11.46-11.26-10.74-17.6a9.953 9.953 0 0 1-9.181-5.775 14.62 14.62 0 0 1 14.25-0.572 19.3 19.3 0 0 0 14.55 0.572c-0.015-0.315-6.76-3-9.39-5.59-1.405-1.385-2.072-2.052-2.663-2.553a11.59 11.59 0 0 0-1-0.758c-0.23-0.157-0.489-0.327-0.8-0.531-2.827-1.838-8.449-1.737-8.635-1.732h-0.018c-1.536-1.947-1.428-8.367-1.34-9.708a6.928 6.928 0 0 0-1.294 0.687 28.22 28.22 0 0 0-3.788 3.245 33.84 33.84 0 0 0-3.638 4.337v6e-3 -7e-3a32.73 32.73 0 0 0-5.2 11.74c-0.019 0.079-1.396 6.099-0.717 9.221z" fill="url(#h)"/>
+  <path d="m52.42 26.86a21.1 21.1 0 0 1 3.6 4.7c0.213 0.161 0.412 0.321 0.581 0.476 8.787 8.1 4.183 19.55 3.84 20.36 7.138-5.881 11.7-14.58 10.33-23.56-4.384-10.93-11.82-15.34-17.88-24.93-0.307-0.485-0.614-0.971-0.913-1.484-0.171-0.293-0.308-0.557-0.427-0.8a7.053 7.053 0 0 1-0.578-1.535 0.1 0.1 0 0 0-0.088-0.1 0.138 0.138 0 0 0-0.073 0c-5e-3 0-0.013 9e-3 -0.019 0.011s-0.019 0.011-0.028 0.015c-1.499 0.711-10.39 14.79 1.66 26.83z" fill="url(#i)"/>
+  <path d="m56.6 32.04c-0.169-0.155-0.368-0.315-0.581-0.476-0.079-0.059-0.157-0.118-0.241-0.177a13.38 13.38 0 0 0-9.345-2.269c13.94 6.97 10.2 30.97-9.119 30.07a17.24 17.24 0 0 1-5.043-0.973q-0.569-0.213-1.138-0.466c-0.219-0.1-0.438-0.2-0.654-0.312l0.027 0.017c2.694 1.839 16 6.332 29.91-5l0.022-0.05c0.347-0.81 4.951-12.26-3.84-20.36z" fill="url(#j)"/>
+  <path d="m21.35 44.74s1.789-6.667 12.81-6.667c1.191 0 4.6-3.325 4.661-4.289a19.3 19.3 0 0 1-14.55-0.572 14.62 14.62 0 0 0-14.25 0.572 9.953 9.953 0 0 0 9.181 5.775c-0.718 6.337 2.632 13.72 10.74 17.6 0.181 0.087 0.351 0.181 0.537 0.264-4.733-2.445-8.641-7.069-9.129-12.68z" fill="url(#k)"/>
+  <path d="m74.62 26.83c-1.684-4.052-5.1-8.427-7.775-9.81a40.27 40.27 0 0 1 3.925 11.76l7e-3 0.065c-4.382-10.92-11.81-15.33-17.88-24.92-0.307-0.485-0.614-0.971-0.913-1.484-0.171-0.293-0.308-0.557-0.427-0.8a7.053 7.053 0 0 1-0.578-1.535 0.1 0.1 0 0 0-0.088-0.1 0.138 0.138 0 0 0-0.073 0c-5e-3 0-0.013 9e-3 -0.019 0.011s-0.019 0.011-0.028 0.015l0.015-0.026c-9.735 5.7-13.04 16.25-13.34 21.53 0.452-0.031 0.9-0.069 1.362-0.069a19.56 19.56 0 0 1 16.98 9.917 13.38 13.38 0 0 0-9.345-2.269c13.94 6.97 10.2 30.97-9.119 30.07a17.24 17.24 0 0 1-5.043-0.973q-0.569-0.213-1.138-0.466c-0.219-0.1-0.438-0.2-0.654-0.312l0.027 0.017q-0.282-0.135-0.564-0.281c0.181 0.087 0.351 0.181 0.537 0.264-4.733-2.446-8.641-7.07-9.129-12.68 0 0 1.789-6.667 12.81-6.667 1.191 0 4.6-3.325 4.661-4.289-0.015-0.315-6.76-3-9.39-5.59-1.405-1.385-2.072-2.052-2.663-2.553a11.59 11.59 0 0 0-1-0.758 17.97 17.97 0 0 1-0.109-9.473 28.7 28.7 0 0 0-9.329 7.21h-0.018c-1.536-1.947-1.428-8.367-1.34-9.708a6.928 6.928 0 0 0-1.294 0.687 28.22 28.22 0 0 0-3.788 3.245 33.84 33.84 0 0 0-3.623 4.347v6e-3 -7e-3a32.73 32.73 0 0 0-5.2 11.74l-0.052 0.256c-0.073 0.341-0.4 2.073-0.447 2.445a45.09 45.09 0 0 0-0.572 5.403v0.2a38.76 38.76 0 0 0 76.95 6.554c0.065-0.5 0.118-0.995 0.176-1.5a39.86 39.86 0 0 0-2.514-19.47zm-3.845 1.991 7e-3 0.041z" fill="url(#l)"/>
+ </g>
+ <metadata>
+  <rdf:RDF>
+   <cc:Work rdf:about="">
+    <dc:title>Firefox Browser logo</dc:title>
+   </cc:Work>
+  </rdf:RDF>
+ </metadata>
+</svg>

--- a/packages/popup/package.json
+++ b/packages/popup/package.json
@@ -17,11 +17,13 @@
     "material-icons": "^1.13.12",
     "preact": "^10.13.1",
     "preact-iso": "^2.3.2",
-    "preact-render-to-string": "^6.3.1"
+    "preact-render-to-string": "^6.3.1",
+    "uuid": "^9.0.1"
   },
   "devDependencies": {
     "@preact/preset-vite": "^2.5.0",
     "@types/bootstrap": "^5.2.10",
+    "@types/uuid": "^9.0.8",
     "@worm/types": "*",
     "sass": "^1.70.0"
   }

--- a/packages/popup/src/components/FileInput.tsx
+++ b/packages/popup/src/components/FileInput.tsx
@@ -24,7 +24,7 @@ function Content() {
   );
 }
 
-export default function FileUpload({ onChange }: FileUploadProps) {
+export default function FileInput({ onChange }: FileUploadProps) {
   const _canUploadDirect = useMemo(canUploadDirect, []);
   const language = useLanguage();
   const message = encodeURIComponent(language.options.DIRECT_UPLOAD_DISALLOWED);

--- a/packages/popup/src/components/FileUpload.tsx
+++ b/packages/popup/src/components/FileUpload.tsx
@@ -1,0 +1,37 @@
+import { useMemo } from "preact/hooks";
+import type { JSXInternal } from "preact/src/jsx";
+
+import {
+  CAN_UPLOAD_PARAMETER,
+  NOTIFY_PARAMETER,
+  ROUTES,
+  canUploadDirect,
+} from "../lib/routes";
+import { useLanguage } from "../lib/language";
+
+type FileUploadProps = {
+  onChange: (event: JSXInternal.TargetedInputEvent<HTMLInputElement>) => void;
+};
+
+const WRAPPER_CLASSNAME = "btn btn-secondary btn-sm";
+
+export default function FileUpload({ onChange }: FileUploadProps) {
+  const _canUploadDirect = useMemo(canUploadDirect, []);
+  const language = useLanguage();
+  const message = encodeURIComponent(language.options.DIRECT_UPLOAD_DISALLOWED);
+
+  return _canUploadDirect ? (
+    <label className={WRAPPER_CLASSNAME}>
+      Import
+      <input accept=".json" hidden type="file" onChange={onChange} />
+    </label>
+  ) : (
+    <a
+      className={WRAPPER_CLASSNAME}
+      href={`${ROUTES.HOME}?${CAN_UPLOAD_PARAMETER}=true&${NOTIFY_PARAMETER}=${message}`}
+      target="_blank"
+    >
+      Import
+    </a>
+  );
+}

--- a/packages/popup/src/components/FileUpload.tsx
+++ b/packages/popup/src/components/FileUpload.tsx
@@ -13,7 +13,16 @@ type FileUploadProps = {
   onChange: (event: JSXInternal.TargetedInputEvent<HTMLInputElement>) => void;
 };
 
-const WRAPPER_CLASSNAME = "btn btn-secondary btn-sm";
+const WRAPPER_CLASSNAME = "btn btn-secondary";
+
+function Content() {
+  return (
+    <span className="d-flex align-items-center gap-1">
+      <i className="material-icons-sharp fs-sm">download</i>
+      Import
+    </span>
+  );
+}
 
 export default function FileUpload({ onChange }: FileUploadProps) {
   const _canUploadDirect = useMemo(canUploadDirect, []);
@@ -22,7 +31,7 @@ export default function FileUpload({ onChange }: FileUploadProps) {
 
   return _canUploadDirect ? (
     <label className={WRAPPER_CLASSNAME}>
-      Import
+      <Content />
       <input accept=".json" hidden type="file" onChange={onChange} />
     </label>
   ) : (
@@ -31,7 +40,7 @@ export default function FileUpload({ onChange }: FileUploadProps) {
       href={`${ROUTES.HOME}?${CAN_UPLOAD_PARAMETER}=true&${NOTIFY_PARAMETER}=${message}`}
       target="_blank"
     >
-      Import
+      <Content />
     </a>
   );
 }

--- a/packages/popup/src/components/HelpRedirect.tsx
+++ b/packages/popup/src/components/HelpRedirect.tsx
@@ -1,0 +1,24 @@
+import { useContext } from "preact/hooks";
+
+import { storageSetByKeys } from "@worm/shared";
+
+import { Config } from "../store/Config";
+
+export default function HelpRedirect({ text = "contact support" }) {
+  const {
+    storage: { preferences },
+  } = useContext(Config);
+
+  const handleClick = () => {
+    const newPreferences = Object.assign({}, preferences);
+    newPreferences.activeTab = "support";
+
+    storageSetByKeys({ preferences: newPreferences });
+  };
+
+  return (
+    <button className="btn btn-link btn-sm p-0 ms-1" onClick={handleClick}>
+      {text}
+    </button>
+  );
+}

--- a/packages/popup/src/components/Layout.tsx
+++ b/packages/popup/src/components/Layout.tsx
@@ -23,6 +23,10 @@ const tabs: { identifier: PopupTab; label: string }[] = [
     label: "Domains",
   },
   {
+    identifier: "options",
+    label: "Options",
+  },
+  {
     identifier: "support",
     label: "Help",
   },

--- a/packages/popup/src/components/Layout.tsx
+++ b/packages/popup/src/components/Layout.tsx
@@ -1,11 +1,12 @@
 import { VNode } from "preact";
-import { useContext } from "preact/hooks";
+import { useContext, useMemo } from "preact/hooks";
 
-import { storageSetByKeys } from "@worm/shared";
+import { getAssetURL, storageSetByKeys } from "@worm/shared";
 import { PopupTab } from "@worm/types";
 
 import { RefreshRequiredToast } from "./RefreshRequiredToast";
 import cx from "../lib/classnames";
+import { getNotificationMessage } from "../lib/routes";
 import { Config } from "../store/Config";
 import { useToast } from "../store/Toast";
 
@@ -37,6 +38,7 @@ export default function Layout({ children }: LayoutProps) {
     storage: { preferences },
   } = useContext(Config);
   const { hideToast, showToast } = useToast();
+  const notificationMessage = useMemo(getNotificationMessage, []);
 
   const handleExtensionEnabledClick = () => {
     const newPreferences = Object.assign({}, preferences);
@@ -64,6 +66,17 @@ export default function Layout({ children }: LayoutProps) {
   return (
     <div className="layout">
       <div className="d-flex flex-column h-100">
+        {notificationMessage && (
+          <div className="alert alert-info d-flex gap-2 rounded-0">
+            <div>
+              <img src={getAssetURL("img/firefox-logo.svg")} />
+            </div>
+            <div>
+              <div className="fw-bold">Firefox detected</div>
+              <div className="fs-sm">{notificationMessage}</div>
+            </div>
+          </div>
+        )}
         <div className="d-flex w-100">
           <div className="d-flex align-items-center justify-content-center">
             <button

--- a/packages/popup/src/components/Layout.tsx
+++ b/packages/popup/src/components/Layout.tsx
@@ -67,7 +67,7 @@ export default function Layout({ children }: LayoutProps) {
     <div className="layout">
       <div className="d-flex flex-column h-100">
         {notificationMessage && (
-          <div className="alert alert-info d-flex gap-2 rounded-0">
+          <div className="alert alert-info d-flex gap-2 rounded-0" role="alert">
             <div>
               <img src={getAssetURL("img/firefox-logo.svg")} />
             </div>

--- a/packages/popup/src/components/Options.tsx
+++ b/packages/popup/src/components/Options.tsx
@@ -1,0 +1,318 @@
+import { useContext, useEffect, useMemo, useRef, useState } from "preact/hooks";
+import type { JSXInternal } from "preact/src/jsx";
+
+import { v4 as uuidv4 } from "uuid";
+
+import { getSchemaByVersion, logDebug, storageSetByKeys } from "@worm/shared";
+import { schemaVersions, type Matcher, type SchemaExport } from "@worm/types";
+
+import HelpRedirect from "./HelpRedirect";
+import RuleRow from "./RuleRow";
+import { Config } from "../store/Config";
+import { useToast } from "../store/Toast";
+
+type Selection = Matcher & {
+  isSelected: boolean;
+};
+
+export default function Options() {
+  const [selected, setSelected] = useState<Selection[]>();
+  const {
+    storage: { matchers },
+  } = useContext(Config);
+  const selectedCount = useMemo(
+    () => selected?.filter((s) => s.isSelected).length ?? 0,
+    [selected]
+  );
+  const { showToast } = useToast();
+  const hideModalButtonRef = useRef<HTMLButtonElement>(null);
+
+  useEffect(() => {
+    setSelected(
+      matchers?.map((matcher) => {
+        let isSelected = false;
+        const selectedIdx =
+          selected?.findIndex(
+            (selected) => selected.identifier === matcher.identifier
+          ) ?? -1;
+
+        if (selected && selectedIdx > -1) {
+          isSelected = selected[selectedIdx].isSelected;
+        }
+
+        return {
+          ...matcher,
+          isSelected,
+        };
+      })
+    );
+  }, matchers);
+
+  const handleExport = () => {
+    const schemaExport: SchemaExport = {
+      version: 1,
+      data: {
+        matchers: matchers?.filter(
+          (matcher) =>
+            selected?.find(
+              (selection) => selection.identifier === matcher.identifier
+            )?.isSelected
+        ),
+      },
+    };
+    const href = `data:text/json;charset=utf-8,${encodeURIComponent(
+      JSON.stringify(schemaExport, null, 2)
+    )}`;
+    const anchor = document.createElement("a");
+
+    anchor.setAttribute("href", href);
+    anchor.setAttribute(
+      "download",
+      `WordReplacerMax_Rules_${new Date().getTime()}.json`
+    );
+    document.body.appendChild(anchor);
+    anchor.click();
+    anchor.remove();
+
+    if (hideModalButtonRef.current) {
+      hideModalButtonRef.current.click();
+      setSelected(undefined);
+    }
+  };
+
+  const handleImport = (
+    event: JSXInternal.TargetedInputEvent<HTMLInputElement>
+  ) => {
+    const input = event.target as HTMLInputElement;
+    const { files } = input;
+
+    if (!files || files.length !== 1) {
+      return;
+    }
+
+    const [file] = files;
+    const fileReader = new FileReader();
+
+    fileReader.onloadend = async () => {
+      const { result } = fileReader;
+
+      try {
+        const parsedJson = JSON.parse(String(result));
+        const schema = getSchemaByVersion(parsedJson.version);
+        const rulesExport = schema.parse(parsedJson);
+        const {
+          data: { matchers: importedMatchers },
+        } = rulesExport;
+
+        if (!importedMatchers || !Boolean(importedMatchers.length)) {
+          return;
+        }
+
+        const rulesToAdd: Matcher[] = importedMatchers.map(
+          (matcher: Matcher) => ({
+            ...matcher,
+            identifier: uuidv4(),
+          })
+        );
+
+        storageSetByKeys({
+          matchers: [...(matchers ?? []), ...rulesToAdd],
+        });
+
+        showToast({
+          children: (
+            <div className="d-flex align-items-center gap-2">
+              <i className="material-icons-sharp fs-6 text-success">check</i>
+              <div>
+                {rulesToAdd.length} rule{rulesToAdd.length > 1 ? "s" : ""}{" "}
+                imported successfully.
+              </div>
+            </div>
+          ),
+        });
+      } catch (err) {
+        logDebug("`handleImport`", err);
+        logDebug("Received file contents", result);
+        showToast({
+          children: (
+            <div className="d-flex align-items-center">
+              It looks like your export file is corrupted. Please{" "}
+              <HelpRedirect />.
+            </div>
+          ),
+        });
+      }
+    };
+
+    fileReader.readAsText(file);
+    input.value = ""; // clear value to allow uploading same file more than once
+  };
+
+  const handleSelectAllChange = (
+    event: JSXInternal.TargetedEvent<HTMLInputElement, Event>
+  ) => {
+    const input = event.target as HTMLInputElement;
+    const { checked } = input;
+
+    if (!selected) return;
+
+    const newSelected = [...selected].map((s) => ({
+      ...s,
+      isSelected: checked,
+    }));
+
+    setSelected(newSelected);
+  };
+
+  const handleSelectionChange =
+    (identifier: string) =>
+    (event: JSXInternal.TargetedEvent<HTMLInputElement, Event>) => {
+      const input = event.target as HTMLInputElement;
+      const { checked } = input;
+      const selectedIdx =
+        selected?.findIndex((matcher) => matcher.identifier === identifier) ??
+        -1;
+
+      if (!selected || selectedIdx < 0) return;
+
+      const newSelected = [...selected];
+      newSelected[selectedIdx].isSelected = checked;
+
+      setSelected(newSelected);
+    };
+
+  return (
+    <div className="container-fluid gx-0 d-flex flex-column gap-2">
+      <div className="row">
+        <div className="col col-sm-8">
+          <div className="fw-bold">Import/Export</div>
+          <p className="fs-sm">
+            Importing rules <i>adds</i> them to your existing list so nothing is
+            lost. When exporting, you may choose to include all rules or only a
+            select few.
+          </p>
+          <div className="d-flex gap-2">
+            <label className="btn btn-secondary btn-sm">
+              Import
+              <input
+                accept=".json"
+                hidden
+                type="file"
+                onChange={handleImport}
+              />
+            </label>
+            <button
+              className="btn btn-secondary btn-sm"
+              data-bs-toggle="modal"
+              data-bs-target="#export-modal"
+              type="button"
+            >
+              Export
+            </button>
+          </div>
+        </div>
+      </div>
+      <div
+        aria-hidden="true"
+        aria-labelledby="export-modalLabel"
+        className="modal fade"
+        id="export-modal"
+      >
+        <div className="modal-dialog modal-fullscreen">
+          <div className="modal-content">
+            <div className="modal-header">
+              <h1 className="modal-title fs-5" id="export-modalLabel">
+                Choose rules to export
+              </h1>
+              <button
+                type="button"
+                className="btn-close"
+                data-bs-dismiss="modal"
+                aria-label="Close"
+              ></button>
+            </div>
+            <div className="modal-body">
+              <div className="d-flex flex-column gap-2">
+                {Boolean(matchers?.length) ? (
+                  <>
+                    <div className="form-check">
+                      <input
+                        className="form-check-input"
+                        type="checkbox"
+                        value=""
+                        id="select-all-checkbox"
+                        onChange={handleSelectAllChange}
+                        checked={selected?.every((s) => s.isSelected)}
+                      />
+                      <label
+                        className="form-check-label ms-2"
+                        for="select-all-checkbox"
+                      >
+                        Select all
+                      </label>
+                    </div>
+                    {matchers?.map((matcher) => (
+                      <div key={matcher.identifier} className="d-flex gap-2">
+                        <div className="form-check mt-1">
+                          <input
+                            className="form-check-input"
+                            type="checkbox"
+                            value=""
+                            id={`matcher-${matcher.identifier}`}
+                            onChange={handleSelectionChange(matcher.identifier)}
+                            checked={
+                              selected?.find(
+                                (s) => s.identifier === matcher.identifier
+                              )?.isSelected
+                            }
+                          />
+                          <label
+                            className="form-check-label ms-2 visually-hidden"
+                            for={`matcher-${matcher.identifier}`}
+                          >
+                            Include
+                          </label>
+                        </div>
+                        <RuleRow
+                          key={matcher.identifier}
+                          matcher={matcher}
+                          matchers={matchers}
+                          isSelecting
+                        />
+                      </div>
+                    ))}
+                  </>
+                ) : (
+                  <div className="alert alert-info" role="alert">
+                    You don't have any rules to export
+                  </div>
+                )}
+              </div>
+            </div>
+            <div className="modal-footer">
+              <button
+                type="button"
+                className="btn btn-secondary"
+                data-bs-dismiss="modal"
+                ref={hideModalButtonRef}
+              >
+                Cancel
+              </button>
+              <button
+                type="button"
+                className="btn btn-primary"
+                disabled={selectedCount === 0}
+                onClick={handleExport}
+              >
+                Export{" "}
+                {selectedCount > 0
+                  ? `${selectedCount} rule${selectedCount > 1 ? "s" : ""}`
+                  : "selected"}
+              </button>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/packages/popup/src/components/Options.tsx
+++ b/packages/popup/src/components/Options.tsx
@@ -109,15 +109,16 @@ export default function Options() {
           return;
         }
 
-        const rulesToAdd: Matcher[] = importedMatchers.map(
+        const enrichedMatchers: Matcher[] = importedMatchers.map(
           (matcher: Matcher) => ({
             ...matcher,
             identifier: uuidv4(),
+            active: true,
           })
         );
 
         storageSetByKeys({
-          matchers: [...(matchers ?? []), ...rulesToAdd],
+          matchers: [...(matchers ?? []), ...enrichedMatchers],
         });
 
         showToast({
@@ -125,8 +126,8 @@ export default function Options() {
             <div className="d-flex align-items-center gap-2">
               <i className="material-icons-sharp fs-6 text-success">check</i>
               <div>
-                {rulesToAdd.length} rule{rulesToAdd.length > 1 ? "s" : ""}{" "}
-                imported successfully.
+                {enrichedMatchers.length} rule
+                {enrichedMatchers.length > 1 ? "s" : ""} imported successfully.
               </div>
             </div>
           ),
@@ -183,25 +184,40 @@ export default function Options() {
     };
 
   return (
-    <div className="container-fluid gx-0 d-flex flex-column gap-2">
-      <div className="row">
-        <div className="col col-sm-8">
-          <div className="fw-bold">Import/Export</div>
-          <p className="fs-sm">
-            Importing rules <i>adds</i> them to your existing list so nothing is
-            lost. When exporting, you may choose to include all rules or only a
-            select few.
-          </p>
-          <div className="d-flex gap-2">
-            <FileUpload onChange={handleImport} />
+    <>
+      <div className="container-fluid gx-0 d-flex flex-column gap-4">
+        <div className="row">
+          <div className="col col-sm-8">
+            <div className="fw-bold">Export</div>
+            <div className="fs-sm mb-2">
+              Export your rules to a local file, enabling you to transfer and
+              share them anywhere. You have the option to export all your rules
+              or only a selected subset.
+            </div>
             <button
-              className="btn btn-secondary btn-sm"
+              className="btn btn-secondary"
               data-bs-toggle="modal"
               data-bs-target="#export-modal"
               type="button"
             >
-              Export
+              <span className="d-flex align-items-center gap-1">
+                <i className="material-icons-sharp fs-sm">upload</i>
+                Export
+              </span>
             </button>
+          </div>
+        </div>
+        <div className="row">
+          <div className="col col-sm-8">
+            <div className="fw-bold">Import</div>
+            <div className="fs-sm mb-2">
+              Easily add to your existing settings by importing new rules. This
+              process is safe &ndash; it won't overwrite your current data, but
+              simply adds the new rules to what you already have.
+            </div>
+            <div className="d-flex gap-2">
+              <FileUpload onChange={handleImport} />
+            </div>
           </div>
         </div>
       </div>
@@ -306,6 +322,6 @@ export default function Options() {
           </div>
         </div>
       </div>
-    </div>
+    </>
   );
 }

--- a/packages/popup/src/components/Options.tsx
+++ b/packages/popup/src/components/Options.tsx
@@ -4,8 +4,9 @@ import type { JSXInternal } from "preact/src/jsx";
 import { v4 as uuidv4 } from "uuid";
 
 import { getSchemaByVersion, logDebug, storageSetByKeys } from "@worm/shared";
-import { schemaVersions, type Matcher, type SchemaExport } from "@worm/types";
+import type { Matcher, SchemaExport } from "@worm/types";
 
+import FileUpload from "./FileUpload";
 import HelpRedirect from "./HelpRedirect";
 import RuleRow from "./RuleRow";
 import { Config } from "../store/Config";
@@ -192,15 +193,7 @@ export default function Options() {
             select few.
           </p>
           <div className="d-flex gap-2">
-            <label className="btn btn-secondary btn-sm">
-              Import
-              <input
-                accept=".json"
-                hidden
-                type="file"
-                onChange={handleImport}
-              />
-            </label>
+            <FileUpload onChange={handleImport} />
             <button
               className="btn btn-secondary btn-sm"
               data-bs-toggle="modal"

--- a/packages/popup/src/components/QueryInput.tsx
+++ b/packages/popup/src/components/QueryInput.tsx
@@ -16,6 +16,7 @@ type QueryInputProps = Pick<
   Matcher,
   "active" | "identifier" | "queries" | "queryPatterns"
 > & {
+  disabled: boolean;
   onChange: (
     identifier: string,
     key: keyof Matcher,
@@ -47,6 +48,7 @@ const queryPatternMetadata: {
 
 export default function QueryInput({
   active,
+  disabled,
   identifier,
   queries,
   queryPatterns,
@@ -111,6 +113,7 @@ export default function QueryInput({
       >
         <input
           className="form-control border-0 rounded-end-0"
+          disabled={disabled}
           enterkeyhint="enter"
           placeholder="Search for..."
           type="text"
@@ -139,6 +142,7 @@ export default function QueryInput({
             <input
               checked={queryPatterns.includes(value)}
               className={cx("btn-check px-0 py-2")}
+              disabled={disabled}
               id={identifier + value}
               type="checkbox"
               onClick={handlePatternChange(value)}

--- a/packages/popup/src/components/ReplacementInput.tsx
+++ b/packages/popup/src/components/ReplacementInput.tsx
@@ -10,6 +10,7 @@ type ReplacementInputProps = Pick<
   Matcher,
   "active" | "identifier" | "queries" | "replacement"
 > & {
+  disabled: boolean;
   onChange: (
     identifier: string,
     key: keyof Matcher,
@@ -19,6 +20,7 @@ type ReplacementInputProps = Pick<
 
 export default function ReplacementInput({
   active,
+  disabled,
   identifier,
   queries,
   replacement,
@@ -52,6 +54,7 @@ export default function ReplacementInput({
     <form className="flex-fill border rounded" onSubmit={handleFormSubmit}>
       <input
         className="form-control border-0"
+        disabled={disabled}
         enterkeyhint="enter"
         size={15}
         type="text"

--- a/packages/popup/src/components/RuleRow.tsx
+++ b/packages/popup/src/components/RuleRow.tsx
@@ -12,13 +12,13 @@ import { useToast } from "../store/Toast";
 type RuleRowProps = {
   matcher: Matcher;
   matchers: Matcher[];
-  isSelecting?: boolean;
+  disabled?: boolean;
 };
 
 export default function RuleRow({
   matcher: { active, identifier, queries, queryPatterns, replacement },
   matchers,
-  isSelecting = false,
+  disabled = false,
 }: RuleRowProps) {
   const [isConfirmingDelete, setIsConfirmingDelete] = useState(false);
   const confirmingDeleteRef = useRef<boolean>();
@@ -101,8 +101,8 @@ export default function RuleRow({
   };
 
   return (
-    <div className={cx("row d-flex", isSelecting && "pe-none flex-fill")}>
-      {!isSelecting && (
+    <div className={cx("row d-flex", disabled && "pe-none flex-fill")}>
+      {!disabled && (
         <div className="col-auto form-check form-switch ps-3 pe-0 pt-2">
           <input
             checked={active}
@@ -124,7 +124,7 @@ export default function RuleRow({
       <div className="col">
         <QueryInput
           active={active}
-          disabled={isSelecting}
+          disabled={disabled}
           identifier={identifier}
           queries={queries}
           queryPatterns={queryPatterns}
@@ -137,14 +137,14 @@ export default function RuleRow({
       <div className="col-auto">
         <ReplacementInput
           active={active}
-          disabled={isSelecting}
+          disabled={disabled}
           identifier={identifier}
           queries={queries}
           replacement={replacement}
           onChange={handleMatcherInputChange}
         />
       </div>
-      {!isSelecting && (
+      {!disabled && (
         <div className="rule-row-actions col-auto ps-0">
           <button
             data-dismiss="delete"

--- a/packages/popup/src/components/RuleRow.tsx
+++ b/packages/popup/src/components/RuleRow.tsx
@@ -12,11 +12,13 @@ import { useToast } from "../store/Toast";
 type RuleRowProps = {
   matcher: Matcher;
   matchers: Matcher[];
+  isSelecting?: boolean;
 };
 
 export default function RuleRow({
   matcher: { active, identifier, queries, queryPatterns, replacement },
   matchers,
+  isSelecting = false,
 }: RuleRowProps) {
   const [isConfirmingDelete, setIsConfirmingDelete] = useState(false);
   const confirmingDeleteRef = useRef<boolean>();
@@ -99,27 +101,30 @@ export default function RuleRow({
   };
 
   return (
-    <div className="row d-flex">
-      <div className="col-auto form-check form-switch ps-3 pe-0 pt-2">
-        <input
-          checked={active}
-          className="form-check-input m-0"
-          id={`active-check-${identifier}`}
-          role="switch"
-          title={active ? "Disable Rule" : "Enable Rule"}
-          type="checkbox"
-          onChange={handleActiveChange(identifier)}
-        />
-        <label
-          className="form-check-label visually-hidden"
-          for={`active-check-${identifier}`}
-        >
-          Active
-        </label>
-      </div>
+    <div className={cx("row d-flex", isSelecting && "pe-none flex-fill")}>
+      {!isSelecting && (
+        <div className="col-auto form-check form-switch ps-3 pe-0 pt-2">
+          <input
+            checked={active}
+            className="form-check-input m-0"
+            id={`active-check-${identifier}`}
+            role="switch"
+            title={active ? "Disable Rule" : "Enable Rule"}
+            type="checkbox"
+            onChange={handleActiveChange(identifier)}
+          />
+          <label
+            className="form-check-label visually-hidden"
+            for={`active-check-${identifier}`}
+          >
+            Active
+          </label>
+        </div>
+      )}
       <div className="col">
         <QueryInput
           active={active}
+          disabled={isSelecting}
           identifier={identifier}
           queries={queries}
           queryPatterns={queryPatterns}
@@ -132,32 +137,35 @@ export default function RuleRow({
       <div className="col-auto">
         <ReplacementInput
           active={active}
+          disabled={isSelecting}
           identifier={identifier}
           queries={queries}
           replacement={replacement}
           onChange={handleMatcherInputChange}
         />
       </div>
-      <div className="rule-row-actions col-auto ps-0">
-        <button
-          data-dismiss="delete"
-          className={cx(
-            "btn",
-            isConfirmingDelete
-              ? "btn-danger"
-              : "btn-light bg-transparent border-0"
-          )}
-          title={isConfirmingDelete ? "Confirm" : "Delete Rule"}
-          onBlur={() => clickawayListener(new MouseEvent(""))}
-          onClick={handleDeleteClick}
-        >
-          <span data-dismiss="delete" className="d-flex align-items-center">
-            <i data-dismiss="delete" className="material-icons-sharp fs-6">
-              {isConfirmingDelete ? "delete" : "close"}
-            </i>
-          </span>
-        </button>
-      </div>
+      {!isSelecting && (
+        <div className="rule-row-actions col-auto ps-0">
+          <button
+            data-dismiss="delete"
+            className={cx(
+              "btn",
+              isConfirmingDelete
+                ? "btn-danger"
+                : "btn-light bg-transparent border-0"
+            )}
+            title={isConfirmingDelete ? "Confirm" : "Delete Rule"}
+            onBlur={() => clickawayListener(new MouseEvent(""))}
+            onClick={handleDeleteClick}
+          >
+            <span data-dismiss="delete" className="d-flex align-items-center">
+              <i data-dismiss="delete" className="material-icons-sharp fs-6">
+                {isConfirmingDelete ? "delete" : "close"}
+              </i>
+            </span>
+          </button>
+        </div>
+      )}
     </div>
   );
 }

--- a/packages/popup/src/components/Support.tsx
+++ b/packages/popup/src/components/Support.tsx
@@ -1,35 +1,43 @@
+export function EmailButton({ text = "contact@logicnow.io" }) {
+  return (
+    <a
+      href="mailto:contact@logicnow.io?subject=Help%20with%20Word%20Replacer%20Max"
+      target="_blank"
+    >
+      {text}
+    </a>
+  );
+}
+
 export default function Support() {
   return (
     <div className="container-fluid gx-0 d-flex flex-column gap-2">
       <div className="row fs-sm">
-        <div className="col col-lg-6">
-          Thanks for using Word Replacer Max. We strive to provide the best
-          possible experience and want to help with any problems you run into.
-          Support tickets opened in the extension store do not always reach our
-          engineers in a timely manner
-          <a
-            href="https://groups.google.com/a/chromium.org/g/chromium-extensions/c/V5As4co1mmI"
-            target="_blank"
-          >
-            [1]
-          </a>
-          , so reaching out via email or GitHub is the best way to get things
-          resolved quickly.
+        <div className="col col-sm-8">
+          <p>
+            Thanks for using Word Replacer Max. We strive to provide the best
+            possible experience and want to help with any problems you run into.
+            Support tickets opened in the extension store do not always reach
+            our engineers in a timely manner
+            <a
+              href="https://groups.google.com/a/chromium.org/g/chromium-extensions/c/V5As4co1mmI"
+              target="_blank"
+            >
+              [1]
+            </a>
+            , so reaching out via email or GitHub is the best way to get things
+            resolved quickly.
+          </p>
         </div>
       </div>
       <div className="row">
-        <div className="col col-lg-6">
+        <div className="col col-sm-8">
           <div className="fw-bold">Email</div>
-          <a
-            href="mailto:contact@logicnow.io?subject=Help%20with%20Word%20Replacer%20Max"
-            target="_blank"
-          >
-            contact@logicnow.io
-          </a>
+          <EmailButton />
         </div>
       </div>
       <div className="row">
-        <div className="col col-lg-6">
+        <div className="col col-sm-8">
           <div className="fw-bold">GitHub</div>
           <a
             href="https://github.com/dan-lovelace/word-replacer-max/issues/new"

--- a/packages/popup/src/lib/language/english.tsx
+++ b/packages/popup/src/lib/language/english.tsx
@@ -4,6 +4,6 @@ export default {
   },
   options: {
     DIRECT_UPLOAD_DISALLOWED:
-      "This tab was opened automatically because your browser does not support uploading files into the extension's Popup Window. You may now proceed with your import and close this window any time.",
+      "We opened this tab for you because Firefox can't upload files directly into the extension's popup window. Feel free to import your files here and close this window when you're done.",
   },
 };

--- a/packages/popup/src/lib/language/english.tsx
+++ b/packages/popup/src/lib/language/english.tsx
@@ -2,4 +2,8 @@ export default {
   rules: {
     REFRESH_REQUIRED: "You must refresh the page to see these changes.",
   },
+  options: {
+    DIRECT_UPLOAD_DISALLOWED:
+      "This tab was opened automatically because your browser does not support uploading files into the extension's Popup Window. You may now proceed with your import and close this window any time.",
+  },
 };

--- a/packages/popup/src/lib/routes.ts
+++ b/packages/popup/src/lib/routes.ts
@@ -1,3 +1,27 @@
+import { isFirefox } from "@worm/shared";
+
+export const CAN_UPLOAD_PARAMETER = "u";
+export const NOTIFY_PARAMETER = "msg";
+
 export const ROUTES = {
   HOME: "/popup.html",
 };
+
+export function canUploadDirect() {
+  if (!isFirefox()) return true;
+
+  try {
+    const search = new URLSearchParams(window.location.search);
+
+    return search.get(CAN_UPLOAD_PARAMETER)?.toLowerCase() === "true";
+  } catch (err) {
+    return true;
+  }
+}
+
+export function getNotificationMessage() {
+  return (
+    new URLSearchParams(window.location.search).get(NOTIFY_PARAMETER) ??
+    undefined
+  );
+}

--- a/packages/popup/src/pages/Home.tsx
+++ b/packages/popup/src/pages/Home.tsx
@@ -1,8 +1,10 @@
 import { useContext } from "preact/hooks";
+import { v4 as uuidv4 } from "uuid";
 
 import { storageSetByKeys } from "@worm/shared";
 
 import DomainInput from "../components/DomainInput";
+import Options from "../components/Options";
 import RuleRow from "../components/RuleRow";
 import Support from "../components/Support";
 import { Config } from "../store/Config";
@@ -18,7 +20,7 @@ export default function HomePage() {
         ...(matchers ?? []),
         {
           active: true,
-          identifier: new Date().getTime().toString(),
+          identifier: uuidv4(),
           queries: [],
           queryPatterns: [],
           replacement: "",
@@ -30,6 +32,7 @@ export default function HomePage() {
   return (
     <div className="container-fluid py-2 flex-fill overflow-y-auto">
       {preferences?.activeTab === "domains" && <DomainInput />}
+      {preferences?.activeTab === "options" && <Options />}
       {preferences?.activeTab === "rules" && (
         <div className="d-flex flex-column gap-2">
           {Boolean(matchers?.length) &&

--- a/packages/popup/src/store/Toast.tsx
+++ b/packages/popup/src/store/Toast.tsx
@@ -89,7 +89,8 @@ export function ToastProvider({ children }: { children: VNode }) {
           "position-fixed end-0 bottom-0",
           "w-auto",
           "me-1 mb-1",
-          `text-bg-${messages?.[0].color}`
+          `text-bg-${messages?.[0].color}`,
+          "z-1"
         )}
         role="alert"
       >

--- a/packages/popup/src/style/index.scss
+++ b/packages/popup/src/style/index.scss
@@ -1,3 +1,5 @@
+$enable-negative-margins: true;
+
 @import "bootstrap/scss/bootstrap";
 
 $inputHeight: 38px;

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -10,7 +10,8 @@
     "test": "echo \"Error: no test specified\" && exit 0"
   },
   "dependencies": {
-    "webextension-polyfill": "^0.10.0"
+    "webextension-polyfill": "^0.10.0",
+    "zod": "^3.22.4"
   },
   "devDependencies": {
     "@types/archiver": "^6.0.2",

--- a/packages/shared/src/assets.ts
+++ b/packages/shared/src/assets.ts
@@ -1,0 +1,13 @@
+import { browser } from "./browser";
+
+const {
+  runtime: { getURL },
+} = browser;
+
+export function getAssetURL(path?: string) {
+  const assetBase = "assets";
+
+  if (!path) return getURL(assetBase);
+
+  return getURL(`${assetBase}/${path}`);
+}

--- a/packages/shared/src/browser.ts
+++ b/packages/shared/src/browser.ts
@@ -1,1 +1,5 @@
 export { default as browser } from "webextension-polyfill";
+
+export function isFirefox() {
+  return /firefox/i.test(navigator.userAgent);
+}

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -2,4 +2,5 @@ export * from "./browser";
 export * from "./debounce";
 export * from "./logging";
 export * from "./replace";
+export * from "./schemas";
 export * from "./storage";

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -1,3 +1,4 @@
+export * from "./assets";
 export * from "./browser";
 export * from "./debounce";
 export * from "./logging";

--- a/packages/shared/src/schemas.ts
+++ b/packages/shared/src/schemas.ts
@@ -26,16 +26,15 @@ export const validatedQueryPattern: z.ZodType<QueryPattern> = z.lazy(() =>
   ])
 );
 
-export const validatedSchemaVersion1Export: z.ZodType<SchemaVersion1> = z.lazy(
-  () =>
-    z.object({
-      version: z.literal(1),
-      data: z.object({ matchers: z.array(validatedMatcher) }),
-    })
+const validatedSchemaVersion1: z.ZodType<SchemaVersion1> = z.lazy(() =>
+  z.object({
+    version: z.literal(1),
+    data: z.object({ matchers: z.array(validatedMatcher) }),
+  })
 );
 
 const schemaVersionMapper: SchemaVersionMapper = {
-  1: validatedSchemaVersion1Export,
+  1: validatedSchemaVersion1,
 };
 
 export function getSchemaByVersion<V extends keyof SchemaVersionMapper>(

--- a/packages/shared/src/schemas.ts
+++ b/packages/shared/src/schemas.ts
@@ -1,0 +1,45 @@
+import { z } from "zod";
+
+import type {
+  Matcher,
+  QueryPattern,
+  SchemaVersion1,
+  SchemaVersionMapper,
+} from "@worm/types";
+
+export const validatedMatcher: z.ZodType<Matcher> = z.lazy(() =>
+  z.object({
+    active: z.boolean(),
+    identifier: z.string(),
+    queries: z.array(z.string()),
+    queryPatterns: z.array(validatedQueryPattern),
+    replacement: z.string(),
+  })
+);
+
+export const validatedQueryPattern: z.ZodType<QueryPattern> = z.lazy(() =>
+  z.union([
+    z.literal("case"),
+    z.literal("default"),
+    z.literal("regex"),
+    z.literal("wholeWord"),
+  ])
+);
+
+export const validatedSchemaVersion1Export: z.ZodType<SchemaVersion1> = z.lazy(
+  () =>
+    z.object({
+      version: z.literal(1),
+      data: z.object({ matchers: z.array(validatedMatcher) }),
+    })
+);
+
+const schemaVersionMapper: SchemaVersionMapper = {
+  1: validatedSchemaVersion1Export,
+};
+
+export function getSchemaByVersion<V extends keyof SchemaVersionMapper>(
+  version: V
+): SchemaVersionMapper[V] {
+  return schemaVersionMapper[version];
+}

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -1,4 +1,7 @@
+import { z } from "zod";
+
 const allQueryPatterns = ["case", "default", "regex", "wholeWord"] as const;
+export const schemaVersions = [1, 2] as const;
 
 export type DomainEffect = "allow" | "deny";
 
@@ -9,6 +12,8 @@ export type Matcher = {
   queryPatterns: QueryPattern[];
   replacement: string;
 };
+
+export type PopupTab = "domains" | "options" | "rules" | "support";
 
 export type QueryPattern = (typeof allQueryPatterns)[number];
 
@@ -28,4 +33,21 @@ export type StorageKeyMap = {
   };
 };
 
-export type PopupTab = "domains" | "rules" | "support";
+export type SchemaExport = SchemaVersion & {
+  version: SchemaVersionType;
+};
+
+export type SchemaVersion = SchemaVersion1; // | SchemaVersion2 | SchemaVersion3...
+
+export type SchemaVersionMapper = {
+  1: z.ZodType<SchemaVersion1>;
+};
+
+export type SchemaVersion1 = {
+  version: 1;
+  data?: {
+    matchers?: Matcher[];
+  };
+};
+
+export type SchemaVersionType = (typeof schemaVersions)[number];

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -1,7 +1,7 @@
 import { z } from "zod";
 
 const allQueryPatterns = ["case", "default", "regex", "wholeWord"] as const;
-export const schemaVersions = [1, 2] as const;
+export const schemaVersions = [1] as const;
 
 export type DomainEffect = "allow" | "deny";
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1479,6 +1479,11 @@
   resolved "https://registry.yarnpkg.com/@types/tough-cookie/-/tough-cookie-4.0.5.tgz#cb6e2a691b70cb177c6e3ae9c1d2e8b2ea8cd304"
   integrity sha512-/Ad8+nIOV7Rl++6f1BdKxFSMgmoqEoYbHRpPcx3JEfv8VRsQe9Z4mCXeJBzxs7mbHY/XOZZuXlRNfhpVPbs6ZA==
 
+"@types/uuid@^9.0.8":
+  version "9.0.8"
+  resolved "https://registry.yarnpkg.com/@types/uuid/-/uuid-9.0.8.tgz#7545ba4fc3c003d6c756f651f3bf163d8f0f29ba"
+  integrity sha512-jg+97EGIcY9AGHJJRaaPVgetKDsrTgbRjQ5Msgjh/DQKEFl0DtyRr/VCOyD1T2R1MNeWPK/u7JoGhlDZnKBAfA==
+
 "@types/webextension-polyfill@^0.10.7":
   version "0.10.7"
   resolved "https://registry.yarnpkg.com/@types/webextension-polyfill/-/webextension-polyfill-0.10.7.tgz#de059250599733a60ed26c8a0c81e21e11183b90"
@@ -6246,7 +6251,7 @@ util-deprecate@^1.0.1, util-deprecate@~1.0.1:
   resolved "https://registry.yarnpkg.com/util-deprecate/-/util-deprecate-1.0.2.tgz#450d4dc9fa70de732762fbd2d4a28981419a0ccf"
   integrity sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==
 
-uuid@^9.0.0:
+uuid@^9.0.0, uuid@^9.0.1:
   version "9.0.1"
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-9.0.1.tgz#e188d4c8853cc722220392c424cd637f32293f30"
   integrity sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==
@@ -6555,3 +6560,8 @@ zip-stream@^5.0.1:
     archiver-utils "^4.0.1"
     compress-commons "^5.0.1"
     readable-stream "^3.6.0"
+
+zod@^3.22.4:
+  version "3.22.4"
+  resolved "https://registry.yarnpkg.com/zod/-/zod-3.22.4.tgz#f31c3a9386f61b1f228af56faa9255e845cf3fff"
+  integrity sha512-iC+8Io04lddc+mVqQ9AZ7OQ2MrUKGN+oIQyq1vemgt46jwCwLfhq7/pwnBnNXXXZb8VTVLKwp9EDkx+ryxIWmg==


### PR DESCRIPTION
# Major

- Adds initial implementation for importing and exporting settings - This applies to only Rules for now but was constructed in a way to support more in the future. Additionally, the schemas are versioned so migration should be manageable without user interference.

# Minor

- A number of other QOL improvements