### PR TITLE
fix(shared): multiple replacements in a single node

### DIFF
--- a/packages/shared/cypress/e2e/replace-all.cy.ts
+++ b/packages/shared/cypress/e2e/replace-all.cy.ts
@@ -83,6 +83,34 @@ describe("replaceAll", () => {
     });
   });
 
+  it.only("does not overwrite surrounding elements", () => {
+    cy.visitMock({
+      targetContents: `
+        <h3 class="h3-mktg mb-4 text-medium">
+          <span data-testid="span" class="text-accent-primary d-block">Lorem ipsum</span>
+          Sit dolor
+        </h3>
+      `,
+    });
+
+    cy.document().then((document) => {
+      replaceAll(
+        [
+          {
+            active: true,
+            identifier: "1234",
+            queries: ["ipsum"],
+            queryPatterns: [],
+            replacement: "sit",
+          },
+        ],
+        document
+      );
+
+      cy.findByTestId("span").should("have.text", "Lorem ipsum");
+    });
+  });
+
   it("maintains text enhancement elements", () => {
     cy.visitMock({
       targetContents: "Lorem <u>ipsum</u> dolor",

--- a/packages/shared/cypress/e2e/replace-all.cy.ts
+++ b/packages/shared/cypress/e2e/replace-all.cy.ts
@@ -9,9 +9,7 @@ describe("replaceAll", () => {
       titleContents: "Lorem ipsum dolor",
     });
 
-    s.html().then(($element) => {
-      const html = $element.get(0) as HTMLHtmlElement;
-
+    cy.document().then((document) => {
       replaceAll(
         [
           {
@@ -22,7 +20,7 @@ describe("replaceAll", () => {
             replacement: "sit",
           },
         ],
-        html
+        document
       );
 
       s.target().should("have.text", "Lorem sit dolor");
@@ -33,7 +31,7 @@ describe("replaceAll", () => {
   it("does not overwrite 'script' elements", () => {
     const headScriptContents = `
       function ipsum() {
-        
+
       }
     `;
     cy.visitMock({
@@ -48,9 +46,7 @@ describe("replaceAll", () => {
       titleContents: "Lorem ipsum dolor",
     });
 
-    s.html().then(($element) => {
-      const html = $element.get(0) as HTMLHtmlElement;
-
+    cy.document().then((document) => {
       replaceAll(
         [
           {
@@ -61,7 +57,7 @@ describe("replaceAll", () => {
             replacement: "sit",
           },
         ],
-        html
+        document
       );
 
       s.script().should("have.text", headScriptContents);
@@ -92,9 +88,7 @@ describe("replaceAll", () => {
       targetContents: "Lorem <u>ipsum</u> dolor",
     });
 
-    s.html().then(($element) => {
-      const html = $element.get(0) as HTMLHtmlElement;
-
+    cy.document().then((document) => {
       replaceAll(
         [
           {
@@ -105,7 +99,7 @@ describe("replaceAll", () => {
             replacement: "sit",
           },
         ],
-        html
+        document
       );
 
       cy.get("u").should("have.text", "sit");
@@ -117,9 +111,7 @@ describe("replaceAll", () => {
       targetContents: "Lorem <u>ipsum</u> dolor",
     });
 
-    s.html().then(($element) => {
-      const html = $element.get(0) as HTMLHtmlElement;
-
+    cy.document().then((document) => {
       replaceAll(
         [
           {
@@ -130,7 +122,7 @@ describe("replaceAll", () => {
             replacement: "sit",
           },
         ],
-        html
+        document
       );
 
       s.target().should("have.text", "Lorem ipsum dolor");

--- a/packages/shared/cypress/e2e/replace-all.cy.ts
+++ b/packages/shared/cypress/e2e/replace-all.cy.ts
@@ -83,7 +83,7 @@ describe("replaceAll", () => {
     });
   });
 
-  it.only("does not overwrite surrounding elements", () => {
+  it("does not overwrite surrounding children", () => {
     cy.visitMock({
       targetContents: `
         <h3 class="h3-mktg mb-4 text-medium">
@@ -99,7 +99,7 @@ describe("replaceAll", () => {
           {
             active: true,
             identifier: "1234",
-            queries: ["ipsum"],
+            queries: ["dolor"],
             queryPatterns: [],
             replacement: "sit",
           },

--- a/packages/shared/cypress/e2e/replace.cy.ts
+++ b/packages/shared/cypress/e2e/replace.cy.ts
@@ -1,6 +1,21 @@
-import { replace } from "@worm/shared/src/replace";
+import { replace, searchNode } from "@worm/shared/src/replace";
+import { QueryPattern } from "@worm/types";
 
 import { selectors as s } from "../lib/selectors";
+
+/**
+ * Utility function to reduce code duplication.
+ */
+function searchAndReplace(
+  element: HTMLElement,
+  query: string,
+  queryPatterns: QueryPattern[],
+  replacement: string
+) {
+  const results = searchNode(element, query, queryPatterns);
+
+  replace(results[0], query, queryPatterns, replacement);
+}
 
 describe("replace", () => {
   describe("default query pattern", () => {
@@ -12,7 +27,7 @@ describe("replace", () => {
       s.target().then(($element) => {
         const target = $element.get(0);
 
-        replace(target, "ipsum", [], "sit");
+        searchAndReplace(target, "ipsum", [], "sit");
         cy.wrap($element).should("have.text", "Lorem sit dolor");
       });
     });
@@ -25,7 +40,7 @@ describe("replace", () => {
       s.target().then(($element) => {
         const target = $element.get(0);
 
-        replace(target, "lorem ipsum", [], "sit");
+        searchAndReplace(target, "lorem ipsum", [], "sit");
         cy.wrap($element).should("have.text", "sit dolor");
       });
     });
@@ -38,8 +53,8 @@ describe("replace", () => {
       s.target().then(($element) => {
         const target = $element.get(0);
 
-        replace(target, "ipsum", [], "sit");
-        replace(target, "dolor", [], "sit");
+        searchAndReplace(target, "ipsum", [], "sit");
+        searchAndReplace(target, "dolor", [], "sit");
         cy.wrap($element).should("have.text", "Lorem sit sit sit amet");
       });
     });
@@ -55,7 +70,7 @@ describe("replace", () => {
       s.target().then(($element) => {
         const target = $element.get(0);
 
-        replace(target, "ipsum", [], "sit");
+        searchAndReplace(target, "ipsum", [], "sit");
         cy.wrap($element)
           .should("have.text", "Lorem sit dolor")
           .should("have.attr", "class", "ipsum");
@@ -70,9 +85,9 @@ describe("replace", () => {
       s.target().then(($element) => {
         const target = $element.get(0);
 
-        replace(target, "Lo", [], "Losit");
-        replace(target, "Lo", [], "Losit");
-        replace(target, "Lo", [], "Losit");
+        searchAndReplace(target, "Lo", [], "Losit");
+        searchAndReplace(target, "Lo", [], "Losit");
+        searchAndReplace(target, "Lo", [], "Losit");
         cy.wrap($element).should("have.text", "Lositrem Ipsum");
       });
     });
@@ -87,7 +102,7 @@ describe("replace", () => {
       s.target().then(($element) => {
         const target = $element.get(0);
 
-        replace(target, "ipsum", ["case"], "sit");
+        searchAndReplace(target, "ipsum", ["case"], "sit");
         cy.wrap($element).should("have.text", "Lorem sit dolor");
       });
     });
@@ -100,7 +115,7 @@ describe("replace", () => {
       s.target().then(($element) => {
         const target = $element.get(0);
 
-        replace(target, "ipsum", ["case"], "sit");
+        searchAndReplace(target, "ipsum", ["case"], "sit");
         cy.wrap($element).should("have.text", "Lorem sit dolor Ipsum sit sit");
       });
     });
@@ -115,7 +130,7 @@ describe("replace", () => {
       s.target().then(($element) => {
         const target = $element.get(0);
 
-        replace(target, "ipsum", ["regex"], "sit");
+        searchAndReplace(target, "ipsum", ["regex"], "sit");
         cy.wrap($element).should("have.text", "Lorem sit dolor");
       });
     });
@@ -128,7 +143,7 @@ describe("replace", () => {
       s.target().then(($element) => {
         const target = $element.get(0);
 
-        replace(target, "ipsum.*", ["regex"], "sit");
+        searchAndReplace(target, "ipsum.*", ["regex"], "sit");
         cy.wrap($element).should("have.text", "Lorem sit");
       });
     });
@@ -141,7 +156,7 @@ describe("replace", () => {
       s.target().then(($element) => {
         const target = $element.get(0);
 
-        replace(target, "^(Lo)+rem[\\s]+i{1}", ["regex"], "sit");
+        searchAndReplace(target, "^(Lo)+rem[\\s]+i{1}", ["regex"], "sit");
         cy.wrap($element).should("have.text", "sitpsum dolor");
       });
     });
@@ -156,7 +171,7 @@ describe("replace", () => {
       s.target().then(($element) => {
         const target = $element.get(0);
 
-        replace(target, "ipsum.", ["wholeWord"], "sit");
+        searchAndReplace(target, "ipsum.", ["wholeWord"], "sit");
         cy.wrap($element).should("have.text", "Lorem ipsum dolor sit ");
       });
     });
@@ -169,7 +184,7 @@ describe("replace", () => {
       s.target().then(($element) => {
         const target = $element.get(0);
 
-        replace(target, "ipsum.", ["wholeWord"], "sit");
+        searchAndReplace(target, "ipsum.", ["wholeWord"], "sit");
         cy.wrap($element).should("have.text", "Lorem ipsum dolor sit sit sit ");
       });
     });
@@ -182,7 +197,7 @@ describe("replace", () => {
       s.target().then(($element) => {
         const target = $element.get(0);
 
-        replace(target, "'Ipsum'", ["wholeWord"], "sit");
+        searchAndReplace(target, "'Ipsum'", ["wholeWord"], "sit");
         cy.wrap($element).should("have.text", "Lorem sit dolor");
       });
     });
@@ -195,7 +210,7 @@ describe("replace", () => {
       s.target().then(($element) => {
         const target = $element.get(0);
 
-        replace(target, "Ipsum", ["wholeWord"], "sit");
+        searchAndReplace(target, "Ipsum", ["wholeWord"], "sit");
         cy.wrap($element).should("have.text", "Lorem 'Ipsum' dolor");
       });
     });
@@ -210,7 +225,20 @@ describe("replace", () => {
       s.target().then(($element) => {
         const target = $element.get(0);
 
-        replace(target, "Ipsum", ["case", "wholeWord"], "sit");
+        searchAndReplace(target, "Ipsum", ["case", "wholeWord"], "sit");
+        cy.wrap($element).should("have.text", "Lorem sit dolor sIpsum ipsum");
+      });
+    });
+
+    it("works for single words with query patterns in a different order", () => {
+      cy.visitMock({
+        targetContents: "Lorem Ipsum dolor sIpsum ipsum",
+      });
+
+      s.target().then(($element) => {
+        const target = $element.get(0);
+
+        searchAndReplace(target, "Ipsum", ["wholeWord", "case"], "sit");
         cy.wrap($element).should("have.text", "Lorem sit dolor sIpsum ipsum");
       });
     });
@@ -223,7 +251,7 @@ describe("replace", () => {
       s.target().then(($element) => {
         const target = $element.get(0);
 
-        replace(target, "Ipsum", ["case", "wholeWord"], "sit");
+        searchAndReplace(target, "Ipsum", ["case", "wholeWord"], "sit");
         cy.wrap($element).should("have.text", "Lorem sit dolor sIpsum sit ");
       });
     });

--- a/packages/shared/cypress/e2e/replace.cy.ts
+++ b/packages/shared/cypress/e2e/replace.cy.ts
@@ -30,6 +30,20 @@ describe("replace", () => {
       });
     });
 
+    it("works for multiple rules in the same element", () => {
+      cy.visitMock({
+        targetContents: "Lorem ipsum dolor sit amet",
+      });
+
+      s.target().then(($element) => {
+        const target = $element.get(0);
+
+        replace(target, "ipsum", [], "sit");
+        replace(target, "dolor", [], "sit");
+        cy.wrap($element).should("have.text", "Lorem sit sit sit amet");
+      });
+    });
+
     it("does not affect element attributes", () => {
       cy.visitMock({
         targetContents: "Lorem Ipsum dolor",
@@ -143,7 +157,7 @@ describe("replace", () => {
         const target = $element.get(0);
 
         replace(target, "ipsum.", ["wholeWord"], "sit");
-        cy.wrap($element).should("have.text", "Lorem ipsum dolor sit");
+        cy.wrap($element).should("have.text", "Lorem ipsum dolor sit ");
       });
     });
 
@@ -156,7 +170,7 @@ describe("replace", () => {
         const target = $element.get(0);
 
         replace(target, "ipsum.", ["wholeWord"], "sit");
-        cy.wrap($element).should("have.text", "Lorem ipsum dolor sit sit sit");
+        cy.wrap($element).should("have.text", "Lorem ipsum dolor sit sit sit ");
       });
     });
 
@@ -210,7 +224,7 @@ describe("replace", () => {
         const target = $element.get(0);
 
         replace(target, "Ipsum", ["case", "wholeWord"], "sit");
-        cy.wrap($element).should("have.text", "Lorem sit dolor sIpsum sit");
+        cy.wrap($element).should("have.text", "Lorem sit dolor sIpsum sit ");
       });
     });
   });

--- a/packages/shared/src/replace.ts
+++ b/packages/shared/src/replace.ts
@@ -77,8 +77,8 @@ function getReplacementHTML(
  * not update blocked elements.
  */
 function updateInnerHTML(targetElement: HTMLElement, newHTML: string) {
-  const isTextTarget = targetElement.nodeType === Node.TEXT_NODE;
-  const targetParent = isTextTarget
+  const isTargetText = targetElement.nodeType === Node.TEXT_NODE;
+  const targetParent = isTargetText
     ? targetElement
     : targetElement.parentElement;
   const parentNodeName = String(targetParent?.nodeName.toLowerCase());
@@ -173,7 +173,14 @@ export function replace(
    * replacing inner HTML because there is no such thing as `innerHTML`.
    */
   const isTextTarget = element.nodeType === Node.TEXT_NODE;
-  const targetElement = isTextTarget ? element.parentElement! : element;
+  const targetElement = isTextTarget ? element.parentElement : element;
+  if (!targetElement) {
+    return logDebug("Error locating target element");
+  }
+
+  /**
+   * Get the element's contents according to the target property.
+   */
   const elementContents = String(targetElement[CONTENTS_PROPERTY]);
 
   /**


### PR DESCRIPTION
## Major

- Fixes a replacement issue where more than one rule could not be applied to a single element - Resolves #9

## Attachments

|Before|After|
|-|-|
|![Screenshot 2024-07-29 at 6 24 57 PM](https://github.com/user-attachments/assets/6038eff2-f23c-4a0d-9c05-7cdf62f4f730)|![Screenshot 2024-07-29 at 8 57 47 PM](https://github.com/user-attachments/assets/07deb973-f35d-4f34-a1df-2bddd463927e)|

## Notes

This was brought up by a user during a product review.
