### PR TITLE
fix(shared): regular expression capturing groups

### DIFF
--- a/packages/shared/cypress/e2e/replace-all.cy.ts
+++ b/packages/shared/cypress/e2e/replace-all.cy.ts
@@ -157,7 +157,7 @@ describe("replaceAll", () => {
     });
   });
 
-  it("works for wikipedia - small", () => {
+  it("works for wikipedia", () => {
     cy.visitMock({
       html: "wiki.html",
     });
@@ -182,6 +182,35 @@ describe("replaceAll", () => {
         "1979 ITU World Triathlon Series"
       );
       s.target().contains("from 1979 to 2016");
+    });
+  });
+
+  it("works for regex negative lookaheads", () => {
+    cy.visitMock({
+      targetContents: `
+        <div data-testid="target-1">Hours: 7,5</div>
+        <div data-testid="target-2">Hours: 8,55</div>
+        <div data-testid="target-3">5Hours: 8,5Lorem</div>
+      `,
+    });
+
+    cy.document().then((document) => {
+      replaceAll(
+        [
+          {
+            active: true,
+            identifier: "ABCD-1234",
+            queries: ["\\b(\\d+),5(?!\\d)"],
+            queryPatterns: ["regex"],
+            replacement: "$1,test",
+          },
+        ],
+        document
+      );
+
+      cy.findByTestId("target-1").should("have.text", "Hours: 7,test");
+      cy.findByTestId("target-2").should("have.text", "Hours: 8,55");
+      cy.findByTestId("target-3").should("have.text", "5Hours: 8,testLorem");
     });
   });
 });

--- a/packages/shared/cypress/e2e/replace.cy.ts
+++ b/packages/shared/cypress/e2e/replace.cy.ts
@@ -161,7 +161,7 @@ describe("replace", () => {
       });
     });
 
-    it("works with advanced patterns", () => {
+    it("works with basic patterns 3", () => {
       cy.visitMock({
         targetContents: "Lorem ipsum dolor",
       });
@@ -171,6 +171,19 @@ describe("replace", () => {
 
         searchAndReplace(target, "^(Lo)+rem[\\s]+i{1}", ["regex"], "sit");
         cy.wrap(target).should("have.text", "sitpsum dolor");
+      });
+    });
+
+    it("works with backreferences", () => {
+      cy.visitMock({
+        targetContents: "Lorem ipsum dolor",
+      });
+
+      s.target().then(($element) => {
+        const target = $element.get(0);
+
+        searchAndReplace(target, "(Lorem)|(ipsum)", ["regex"], "$1,updated");
+        cy.wrap(target).should("have.text", "Lorem,updated ,updated dolor");
       });
     });
   });

--- a/packages/shared/src/replace.ts
+++ b/packages/shared/src/replace.ts
@@ -173,10 +173,14 @@ export function replace(
           break;
         }
         case "regex": {
-          replaced = elementContents.replace(
+          // replace by string first to avoid dropping references
+          const regexReplaced = elementContents.replace(
             patternRegex[pattern](query, getRegexFlags(queryPatterns)),
-            () => getReplacementHTML(element, query, replacement)
+            replacement
           );
+
+          // apply the HTML after replacement
+          replaced = getReplacementHTML(element, query, regexReplaced);
           break;
         }
         case "wholeWord": {


### PR DESCRIPTION
## Major

- Fixes a major issue with regular expression capturing groups introduced by #10 - References were being dropped as a result of using a function in Javascript's [replace](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/replace). This has been resolved by first using the built-in replacement patterns then add the necessary wrapping HTML.