### PR TITLE
feat(popup): create rule from text selection

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
     "name": "dan-lovelace",
     "url": "https://github.com/dan-lovelace/word-replacer-max"
   },
-  "version": "0.4.2",
+  "version": "0.5.0",
   "license": "MIT",
   "description": "A browser extension for replacing text on web pages",
   "type": "module",

--- a/package.json
+++ b/package.json
@@ -55,6 +55,7 @@
         }
       ],
       "permissions": [
+        "contextMenus",
         "storage"
       ],
       "web_accessible_resources": [
@@ -95,6 +96,7 @@
         }
       ],
       "permissions": [
+        "contextMenus",
         "storage"
       ],
       "web_accessible_resources": [

--- a/packages/background/src/index.ts
+++ b/packages/background/src/index.ts
@@ -1,49 +1,9 @@
-import { v4 as uuidv4 } from "uuid";
+import { browser } from "@worm/shared";
 
-import { browser, storageGetByKeys, storageSetByKeys } from "@worm/shared";
-import { Matcher } from "@worm/types";
+import { initializeContextMenu } from "./lib/context-menu";
+import { initializeStorage } from "./lib/storage";
 
 browser.runtime.onInstalled.addListener(async () => {
-  const { domainList, matchers, preferences } = await storageGetByKeys([
-    "domainList",
-    "matchers",
-    "preferences",
-  ]);
-
-  if (domainList === undefined) {
-    await storageSetByKeys({
-      domainList: ["docs.google.com", "github.com"],
-    });
-  }
-
-  if (matchers === undefined) {
-    const defaultMatchers: Matcher[] = [
-      {
-        active: true,
-        identifier: uuidv4(),
-        queries: ["my jaw dropped", "I was shocked"],
-        queryPatterns: [],
-        replacement: "I was surprised",
-      },
-      {
-        active: true,
-        identifier: uuidv4(),
-        queries: ["This."],
-        queryPatterns: ["case", "wholeWord"],
-        replacement: "",
-      },
-    ];
-
-    await storageSetByKeys({ matchers: defaultMatchers });
-  }
-
-  if (preferences === undefined) {
-    await storageSetByKeys({
-      preferences: {
-        activeTab: "rules",
-        domainListEffect: "deny",
-        extensionEnabled: true,
-      },
-    });
-  }
+  initializeContextMenu();
+  initializeStorage();
 });

--- a/packages/background/src/lib/context-menu.ts
+++ b/packages/background/src/lib/context-menu.ts
@@ -1,0 +1,63 @@
+import { v4 as uuidv4 } from "uuid";
+
+import {
+  browser,
+  logDebug,
+  storageGetByKeys,
+  storageSetByKeys,
+} from "@worm/shared";
+import { Matcher } from "@worm/types";
+
+const ADD_NEW_RULE_ID = "add-new-rule";
+
+export function initializeContextMenu() {
+  browser.contextMenus.create({
+    id: ADD_NEW_RULE_ID,
+    title: 'Replace "%s"',
+    contexts: ["selection"],
+  });
+
+  browser.contextMenus.onClicked.addListener(async (info) => {
+    switch (info.menuItemId) {
+      case ADD_NEW_RULE_ID: {
+        const { selectionText } = info;
+
+        if (!selectionText) break;
+
+        const { matchers, preferences } = await storageGetByKeys([
+          "matchers",
+          "preferences",
+        ]);
+        const newPreferences = Object.assign({}, preferences);
+        const identifier = uuidv4();
+        const newMatchers: Matcher[] = [
+          ...(matchers ?? []),
+          {
+            active: true,
+            identifier,
+            queries: [selectionText],
+            queryPatterns: [],
+            replacement: "",
+          },
+        ];
+
+        newPreferences.focusRule = identifier;
+
+        storageSetByKeys({
+          matchers: newMatchers,
+          preferences: newPreferences,
+        });
+
+        /**
+         * Attempt to open the popup. This is not widely supported at this
+         * time.
+         */
+        browser.action
+          .openPopup()
+          .catch((err) => logDebug("Error opening popup", err));
+
+        break;
+      }
+    }
+  });
+}

--- a/packages/background/src/lib/context-menu.ts
+++ b/packages/background/src/lib/context-menu.ts
@@ -2,7 +2,7 @@ import { v4 as uuidv4 } from "uuid";
 
 import {
   browser,
-  logDebug,
+  popoutExtension,
   storageGetByKeys,
   storageSetByKeys,
 } from "@worm/shared";
@@ -49,12 +49,14 @@ export function initializeContextMenu() {
         });
 
         /**
-         * Attempt to open the popup. This is not widely supported at this
-         * time.
+         * Attempt to open the popup using a developmental API. Fall back to
+         * opening a new window when it's not supported.
          */
-        browser.action
-          .openPopup()
-          .catch((err) => logDebug("Error opening popup", err));
+        try {
+          browser.action.openPopup();
+        } catch (err) {
+          popoutExtension();
+        }
 
         break;
       }

--- a/packages/background/src/lib/storage.ts
+++ b/packages/background/src/lib/storage.ts
@@ -1,9 +1,23 @@
 import { v4 as uuidv4 } from "uuid";
 
-import { storageGetByKeys, storageSetByKeys } from "@worm/shared";
+import {
+  CURRENT_STORAGE_VERSION,
+  storageGetByKeys,
+  storageSetByKeys,
+} from "@worm/shared";
 import { Matcher } from "@worm/types";
 
 export async function initializeStorage() {
+  const { storageVersion } = await storageGetByKeys(["storageVersion"]);
+
+  if (storageVersion === undefined) {
+    await storageSetByKeys({
+      storageVersion: CURRENT_STORAGE_VERSION,
+    });
+  } else if (storageVersion !== CURRENT_STORAGE_VERSION) {
+    // perform any necessary migrations before proceeding
+  }
+
   const { domainList, matchers, preferences } = await storageGetByKeys([
     "domainList",
     "matchers",

--- a/packages/background/src/lib/storage.ts
+++ b/packages/background/src/lib/storage.ts
@@ -1,0 +1,50 @@
+import { v4 as uuidv4 } from "uuid";
+
+import { storageGetByKeys, storageSetByKeys } from "@worm/shared";
+import { Matcher } from "@worm/types";
+
+export async function initializeStorage() {
+  const { domainList, matchers, preferences } = await storageGetByKeys([
+    "domainList",
+    "matchers",
+    "preferences",
+  ]);
+
+  if (domainList === undefined) {
+    await storageSetByKeys({
+      domainList: ["docs.google.com", "github.com"],
+    });
+  }
+
+  if (matchers === undefined) {
+    const defaultMatchers: Matcher[] = [
+      {
+        active: true,
+        identifier: uuidv4(),
+        queries: ["my jaw dropped", "I was shocked"],
+        queryPatterns: [],
+        replacement: "I was surprised",
+      },
+      {
+        active: true,
+        identifier: uuidv4(),
+        queries: ["This."],
+        queryPatterns: ["case", "wholeWord"],
+        replacement: " ",
+      },
+    ];
+
+    await storageSetByKeys({ matchers: defaultMatchers });
+  }
+
+  if (preferences === undefined) {
+    await storageSetByKeys({
+      preferences: {
+        activeTab: "rules",
+        domainListEffect: "deny",
+        extensionEnabled: true,
+        focusRule: "",
+      },
+    });
+  }
+}

--- a/packages/popup/src/components/Chip.tsx
+++ b/packages/popup/src/components/Chip.tsx
@@ -1,3 +1,5 @@
+import cx from "../lib/classnames";
+
 type ChipProps = {
   identifier: string;
   onRemove: (identifier: string) => () => void;
@@ -5,10 +7,17 @@ type ChipProps = {
 
 export default function Chip({ identifier, onRemove }: ChipProps) {
   return (
-    <span className="d-flex align-items-center badge fs-6 rounded-pill text-bg-light flex-fill-0 pe-0">
+    <span
+      className={cx(
+        "badge",
+        "d-flex align-items-center flex-fill-0 pe-0",
+        "fs-6 text-bg-light text-start text-wrap"
+      )}
+    >
       {identifier}
       <button
-        className="bg-transparent border-0"
+        className="bg-transparent border-0 px-0 mx-1 text-secondary"
+        title="Remove search query"
         type="button"
         onClick={onRemove(identifier)}
       >

--- a/packages/popup/src/components/FileInput.tsx
+++ b/packages/popup/src/components/FileInput.tsx
@@ -1,10 +1,11 @@
 import { useMemo } from "preact/hooks";
 import type { JSXInternal } from "preact/src/jsx";
 
+import { POPUP_ROUTES } from "@worm/shared";
+
 import {
   CAN_UPLOAD_PARAMETER,
   NOTIFY_PARAMETER,
-  ROUTES,
   canUploadDirect,
 } from "../lib/routes";
 import { useLanguage } from "../lib/language";
@@ -37,7 +38,7 @@ export default function FileInput({ onChange }: FileUploadProps) {
   ) : (
     <a
       className={WRAPPER_CLASSNAME}
-      href={`${ROUTES.HOME}?${CAN_UPLOAD_PARAMETER}=true&${NOTIFY_PARAMETER}=${message}`}
+      href={`${POPUP_ROUTES.HOME}?${CAN_UPLOAD_PARAMETER}=true&${NOTIFY_PARAMETER}=${message}`}
       target="_blank"
     >
       <Content />

--- a/packages/popup/src/components/Layout.tsx
+++ b/packages/popup/src/components/Layout.tsx
@@ -1,7 +1,7 @@
 import { VNode } from "preact";
 import { useContext, useEffect, useMemo, useRef } from "preact/hooks";
 
-import { getAssetURL, storageSetByKeys } from "@worm/shared";
+import { getAssetURL, popoutExtension, storageSetByKeys } from "@worm/shared";
 import { PopupTab } from "@worm/types";
 
 import IconButton from "./IconButton";
@@ -9,9 +9,8 @@ import { RefreshRequiredToast } from "./RefreshRequiredToast";
 import ToastMessage from "./ToastMessage";
 
 import cx from "../lib/classnames";
-import { POPPED_OUT_PARAMETER_KEY } from "../lib/config";
 import { useLanguage } from "../lib/language";
-import { getNotificationMessage, ROUTES } from "../lib/routes";
+import { getNotificationMessage } from "../lib/routes";
 import { Config } from "../store/Config";
 import { useToast } from "../store/Toast";
 
@@ -70,12 +69,8 @@ export default function Layout({ children }: LayoutProps) {
     });
   };
 
-  const handlePopoutClick = () => {
-    const open = window.open(
-      `${ROUTES.HOME}?${POPPED_OUT_PARAMETER_KEY}=true`,
-      "popup",
-      "popup=true,width=900,height=700"
-    );
+  const handlePopoutClick = async () => {
+    const open = await popoutExtension();
 
     if (!open) {
       return showToast({

--- a/packages/popup/src/components/Layout.tsx
+++ b/packages/popup/src/components/Layout.tsx
@@ -34,7 +34,6 @@ const tabs: { identifier: PopupTab; isHidden?: boolean; label: string }[] = [
   },
   {
     identifier: "support",
-    isHidden: true,
     label: "Help",
   },
 ];
@@ -150,48 +149,31 @@ export default function Layout({ children }: LayoutProps) {
             )}
           </ul>
           <div className="d-flex align-items-center justify-content-center">
-            <div className="dropdown">
-              <IconButton
-                aria-expanded={false}
-                icon="more_vert"
-                data-bs-toggle="dropdown"
-              />
-              <ul className="dropdown-menu shadow">
-                {!isPoppedOut && (
-                  <>
-                    <li>
-                      <button
-                        className="dropdown-item"
-                        type="button"
-                        onClick={handlePopoutClick}
-                      >
-                        <span className="d-flex align-items-center gap-3">
-                          <span className="material-icons-sharp">
-                            open_in_new
-                          </span>{" "}
-                          Pop extension out
-                        </span>
-                      </button>
-                    </li>
-                    <li>
-                      <hr class="dropdown-divider" />
-                    </li>
-                  </>
-                )}
-                <li>
-                  <button
-                    className="dropdown-item"
-                    type="button"
-                    onClick={handleTabChange("support")}
-                  >
-                    <span className="d-flex align-items-center gap-3">
-                      <span className="material-icons-sharp">support</span> Get
-                      help
-                    </span>
-                  </button>
-                </li>
-              </ul>
-            </div>
+            {!isPoppedOut && (
+              <div className="dropdown">
+                <IconButton
+                  aria-expanded={false}
+                  icon="more_vert"
+                  data-bs-toggle="dropdown"
+                />
+                <ul className="dropdown-menu shadow">
+                  <li>
+                    <button
+                      className="dropdown-item"
+                      type="button"
+                      onClick={handlePopoutClick}
+                    >
+                      <span className="d-flex align-items-center gap-3">
+                        <span className="material-icons-sharp">
+                          open_in_new
+                        </span>{" "}
+                        Pop extension out
+                      </span>
+                    </button>
+                  </li>
+                </ul>
+              </div>
+            )}
           </div>
         </div>
         {children}

--- a/packages/popup/src/components/ReplacementInput.tsx
+++ b/packages/popup/src/components/ReplacementInput.tsx
@@ -1,3 +1,4 @@
+import { Ref } from "preact";
 import { useState } from "preact/hooks";
 import { JSXInternal } from "preact/src/jsx";
 
@@ -11,6 +12,7 @@ type ReplacementInputProps = Pick<
   "active" | "identifier" | "queries" | "replacement"
 > & {
   disabled: boolean;
+  inputRef: Ref<HTMLInputElement>;
   onChange: (
     identifier: string,
     key: keyof Matcher,
@@ -22,6 +24,7 @@ export default function ReplacementInput({
   active,
   disabled,
   identifier,
+  inputRef,
   queries,
   replacement,
   onChange,
@@ -56,6 +59,7 @@ export default function ReplacementInput({
         className="form-control border-0"
         disabled={disabled}
         enterkeyhint="enter"
+        ref={inputRef}
         size={15}
         type="text"
         value={value}

--- a/packages/popup/src/components/Support.tsx
+++ b/packages/popup/src/components/Support.tsx
@@ -18,18 +18,37 @@ export default function Support() {
         <div className={COPY_CONTAINER_COL_CLASS}>
           <div className="fs-5 fw-bold mb-1">Contact Us</div>
           <p>
-            Thanks for using Word Replacer Max. We strive to provide the best
-            possible experience and want to help with any problems you run into.
-            Support tickets opened in the extension store do not always reach
-            our engineers in a timely manner
+            Having trouble with Word Replacer Max? We're here to help! Our goal
+            is to provide you with the best possible experience and promptly
+            address any issues you encounter. The extension is actively
+            maintained, and a fix for your issue is likely just a day or two
+            away.
+          </p>
+          <p>
+            Please note that support tickets submitted through the extension
+            store might not reach our engineers in a timely manner
             <a
               href="https://groups.google.com/a/chromium.org/g/chromium-extensions/c/V5As4co1mmI"
               target="_blank"
             >
               [1]
             </a>
-            , so reaching out via email or GitHub is the best way to get things
-            resolved quickly.
+            . The quickest way to get your issues resolved is by contacting us
+            via email or logging an issue on GitHub.
+          </p>
+          <p>
+            When reaching out, please provide as much context as possible:
+            <ol>
+              <li>The website URL where you're trying to replace text</li>
+              <li>
+                Your rulesets (these can be exported from the Options page and
+                attached as a file)
+              </li>
+              <li>
+                A detailed description of what you expect to happen versus what
+                is actually happening
+              </li>
+            </ol>
           </p>
         </div>
       </div>
@@ -46,7 +65,7 @@ export default function Support() {
             href="https://github.com/dan-lovelace/word-replacer-max/issues/new"
             target="_blank"
           >
-            Create new issue
+            Create a new issue
           </a>
         </div>
       </div>

--- a/packages/popup/src/index.tsx
+++ b/packages/popup/src/index.tsx
@@ -1,10 +1,11 @@
 import { render } from "preact";
 import { LocationProvider, Router, Route } from "preact-iso";
 
+import { POPUP_ROUTES } from "@worm/shared";
+
 import "bootstrap/js/dist/toast";
 
 import Layout from "./components/Layout";
-import { ROUTES } from "./lib/routes";
 import HomePage from "./pages/Home";
 import NotFoundPage from "./pages/NotFound";
 import { ConfigProvider } from "./store/Config";
@@ -20,7 +21,7 @@ export function App() {
         <LocationProvider>
           <Layout>
             <Router>
-              <Route path={ROUTES.HOME} component={HomePage} />
+              <Route path={POPUP_ROUTES.HOME} component={HomePage} />
               <Route default component={NotFoundPage} />
             </Router>
           </Layout>

--- a/packages/popup/src/lib/config.ts
+++ b/packages/popup/src/lib/config.ts
@@ -1,1 +1,0 @@
-export const POPPED_OUT_PARAMETER_KEY = "expanded";

--- a/packages/popup/src/lib/routes.ts
+++ b/packages/popup/src/lib/routes.ts
@@ -3,10 +3,6 @@ import { isFirefox } from "@worm/shared";
 export const CAN_UPLOAD_PARAMETER = "u";
 export const NOTIFY_PARAMETER = "msg";
 
-export const ROUTES = {
-  HOME: "/popup.html",
-};
-
 export function canUploadDirect() {
   if (!isFirefox()) return true;
 

--- a/packages/popup/src/pages/NotFound.tsx
+++ b/packages/popup/src/pages/NotFound.tsx
@@ -1,11 +1,11 @@
-import { ROUTES } from "../lib/routes";
+import { POPUP_ROUTES } from "@worm/shared";
 
 export default function NotFoundPage() {
   return (
     <div>
       <h1>Page Not Found</h1>
       <p>
-        <a href={ROUTES.HOME}>Go Home</a>
+        <a href={POPUP_ROUTES.HOME}>Go Home</a>
       </p>
     </div>
   );

--- a/packages/popup/src/store/Config.tsx
+++ b/packages/popup/src/store/Config.tsx
@@ -1,10 +1,12 @@
 import { VNode, createContext } from "preact";
 import { useEffect, useMemo, useState } from "preact/hooks";
 
-import { browser, storageGetByKeys } from "@worm/shared";
+import {
+  browser,
+  POPUP_POPPED_OUT_PARAMETER_KEY,
+  storageGetByKeys,
+} from "@worm/shared";
 import { Storage } from "@worm/types";
-
-import { POPPED_OUT_PARAMETER_KEY } from "../lib/config";
 
 type ConfigType = {
   isPoppedOut: boolean;
@@ -28,7 +30,7 @@ export function ConfigProvider({ children }: { children: VNode }) {
   const isPoppedOut = useMemo(
     () =>
       new URLSearchParams(window.location.search).get(
-        POPPED_OUT_PARAMETER_KEY
+        POPUP_POPPED_OUT_PARAMETER_KEY
       ) === "true",
     []
   );

--- a/packages/shared/cypress/e2e/replace-all.cy.ts
+++ b/packages/shared/cypress/e2e/replace-all.cy.ts
@@ -213,4 +213,58 @@ describe("replaceAll", () => {
       cy.findByTestId("target-3").should("have.text", "5Hours: 8,testLorem");
     });
   });
+
+  it("does not overwrite text input value", () => {
+    cy.visitMock({
+      bodyContents: `
+        <input data-testid="input-target" type="text" value="Lorem ipsum dolor"></input>
+        <div data-testid="target">Lorem ipsum dolor</div>
+      `,
+    });
+
+    cy.document().then((document) => {
+      replaceAll(
+        [
+          {
+            active: true,
+            identifier: "ABCD-1234",
+            queries: ["ipsum"],
+            queryPatterns: [],
+            replacement: "sit",
+          },
+        ],
+        document
+      );
+
+      cy.findByTestId("input-target").should("have.value", "Lorem ipsum dolor");
+      s.target().should("have.text", "Lorem sit dolor");
+    });
+  });
+
+  it("does not overwrite textarea input value", () => {
+    cy.visitMock({
+      bodyContents: `
+        <textarea data-testid="input-target">Lorem ipsum dolor</textarea>
+        <div data-testid="target">Lorem ipsum dolor</div>
+      `,
+    });
+
+    cy.document().then((document) => {
+      replaceAll(
+        [
+          {
+            active: true,
+            identifier: "ABCD-1234",
+            queries: ["ipsum"],
+            queryPatterns: [],
+            replacement: "sit",
+          },
+        ],
+        document
+      );
+
+      cy.findByTestId("input-target").should("have.text", "Lorem ipsum dolor");
+      s.target().should("have.text", "Lorem sit dolor");
+    });
+  });
 });

--- a/packages/shared/cypress/e2e/replace-all.cy.ts
+++ b/packages/shared/cypress/e2e/replace-all.cy.ts
@@ -267,4 +267,29 @@ describe("replaceAll", () => {
       s.target().should("have.text", "Lorem sit dolor");
     });
   });
+
+  it("does not overwrite elements that have the 'contenteditable' attribute", () => {
+    cy.visitMock({
+      bodyContents: `
+        <div data-testid="target" contenteditable>Lorem ipsum dolor</div>
+      `,
+    });
+
+    cy.document().then((document) => {
+      replaceAll(
+        [
+          {
+            active: true,
+            identifier: "ABCD-1234",
+            queries: ["ipsum"],
+            queryPatterns: [],
+            replacement: "sit",
+          },
+        ],
+        document
+      );
+
+      s.target().should("have.text", "Lorem ipsum dolor");
+    });
+  });
 });

--- a/packages/shared/cypress/e2e/replace.cy.ts
+++ b/packages/shared/cypress/e2e/replace.cy.ts
@@ -72,6 +72,32 @@ describe("replace", () => {
       });
     });
 
+    it("works for whitespace replacements", () => {
+      cy.visitMock({
+        targetContents: "Lorem ipsum dolor",
+      });
+
+      s.target().then(($element) => {
+        const target = $element.get(0);
+
+        searchAndReplace(target, "ipsum", [], " ");
+        cy.wrap(target).should("have.text", "Lorem   dolor");
+      });
+    });
+
+    it("does not replace when replacement is empty", () => {
+      cy.visitMock({
+        targetContents: "Lorem ipsum dolor",
+      });
+
+      s.target().then(($element) => {
+        const target = $element.get(0);
+
+        searchAndReplace(target, "ipsum", [], "");
+        cy.wrap(target).should("have.text", "Lorem ipsum dolor");
+      });
+    });
+
     it("does not affect element attributes", () => {
       cy.visitMock({
         targetContents: "Lorem Ipsum dolor",

--- a/packages/shared/cypress/e2e/replace.cy.ts
+++ b/packages/shared/cypress/e2e/replace.cy.ts
@@ -198,7 +198,7 @@ describe("replace", () => {
         const target = $element.get(0);
 
         searchAndReplace(target, "ipsum.", ["wholeWord"], "sit");
-        cy.wrap(target).should("have.text", "Lorem ipsum dolor sit ");
+        cy.wrap(target).should("have.text", "Lorem ipsum dolor sit");
       });
     });
 
@@ -211,11 +211,24 @@ describe("replace", () => {
         const target = $element.get(0);
 
         searchAndReplace(target, "ipsum.", ["wholeWord"], "sit");
-        cy.wrap(target).should("have.text", "Lorem ipsum dolor sit sit sit ");
+        cy.wrap(target).should("have.text", "Lorem ipsum dolor sit sit sit");
       });
     });
 
-    it("works when surrounded by punctuation", () => {
+    it("works when followed by punctuation", () => {
+      cy.visitMock({
+        targetContents: "Lorem ipsum, dolor",
+      });
+
+      s.target().then(($element) => {
+        const target = $element.get(0);
+        console.log("target", target);
+        searchAndReplace(target, "ipsum", ["wholeWord"], "sit");
+        cy.wrap(target).should("have.text", "Lorem sit, dolor");
+      });
+    });
+
+    it("works with queries surrounded by punctuation", () => {
       cy.visitMock({
         targetContents: "Lorem 'Ipsum' dolor",
       });
@@ -228,7 +241,7 @@ describe("replace", () => {
       });
     });
 
-    it("does not affect query words surrounded by punctuation", () => {
+    it("works with replacements surrounded by punctuation", () => {
       cy.visitMock({
         targetContents: "Lorem 'Ipsum' dolor",
       });
@@ -237,7 +250,7 @@ describe("replace", () => {
         const target = $element.get(0);
 
         searchAndReplace(target, "Ipsum", ["wholeWord"], "sit");
-        cy.wrap(target).should("have.text", "Lorem 'Ipsum' dolor");
+        cy.wrap(target).should("have.text", "Lorem 'sit' dolor");
       });
     });
   });
@@ -278,7 +291,7 @@ describe("replace", () => {
         const target = $element.get(0);
 
         searchAndReplace(target, "Ipsum", ["case", "wholeWord"], "sit");
-        cy.wrap(target).should("have.text", "Lorem sit dolor sIpsum sit ");
+        cy.wrap(target).should("have.text", "Lorem sit dolor sIpsum sit");
       });
     });
   });

--- a/packages/shared/cypress/e2e/replace.cy.ts
+++ b/packages/shared/cypress/e2e/replace.cy.ts
@@ -248,7 +248,7 @@ describe("replace", () => {
 
       s.target().then(($element) => {
         const target = $element.get(0);
-        console.log("target", target);
+
         searchAndReplace(target, "ipsum", ["wholeWord"], "sit");
         cy.wrap(target).should("have.text", "Lorem sit, dolor");
       });

--- a/packages/shared/cypress/e2e/search-node.cy.ts
+++ b/packages/shared/cypress/e2e/search-node.cy.ts
@@ -209,7 +209,6 @@ describe("searchNode", () => {
           <div>
             <span>Lorem Ipsum.</span>
 
-            <span>Lorem .Ipsum.</span>
             <span>Lorem .Ipsum</span>
             <span>Lorem Ipsum/</span>
             <span>Lorem Ipsum-</span>
@@ -232,7 +231,6 @@ describe("searchNode", () => {
           <div>
             <span>Lorem Ipsum-</span>
 
-            <span>Lorem -Ipsum-</span>
             <span>Lorem -Ipsum</span>
             <span>Lorem Ipsum/</span>
             <span>Lorem Ipsum_</span>

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -4,6 +4,7 @@ export * from "./debounce";
 export * from "./domains";
 export * from "./logging";
 export * from "./matchers";
+export * from "./popup";
 export * from "./replace";
 export * from "./schemas";
 export * from "./storage";

--- a/packages/shared/src/popup.ts
+++ b/packages/shared/src/popup.ts
@@ -13,9 +13,9 @@ export async function popoutExtension() {
   const url = `${popupLocation}?${POPUP_POPPED_OUT_PARAMETER_KEY}=true`;
 
   const open = await browser.windows.create({
-    url,
-    type: "popup",
     height: 700,
+    type: "popup",
+    url,
     width: 900,
   });
 

--- a/packages/shared/src/popup.ts
+++ b/packages/shared/src/popup.ts
@@ -1,0 +1,27 @@
+import { browser } from "./browser";
+import { logDebug } from "./logging";
+
+const POPUP_FILENAME = "popup.html";
+
+export const POPUP_POPPED_OUT_PARAMETER_KEY = "expanded";
+export const POPUP_ROUTES = {
+  HOME: `/${POPUP_FILENAME}`,
+};
+
+export async function popoutExtension() {
+  const popupLocation = browser.runtime.getURL(POPUP_FILENAME);
+  const url = `${popupLocation}?${POPUP_POPPED_OUT_PARAMETER_KEY}=true`;
+
+  const open = await browser.windows.create({
+    url,
+    type: "popup",
+    height: 700,
+    width: 900,
+  });
+
+  if (!open) {
+    logDebug("Error opening popup");
+  }
+
+  return open;
+}

--- a/packages/shared/src/replace.ts
+++ b/packages/shared/src/replace.ts
@@ -9,7 +9,7 @@ const REPLACEMENT_WRAPPER_ELEMENT = "span";
 const escapeRegex = (str: string) =>
   str.replace(/[/\-\\^$*+?.()|[\]{}]/g, "\\$&");
 
-const parentNodeBlocklist: Node["nodeName"][] = [
+const nodeNameBlocklist: Set<Node["nodeName"]> = new Set([
   "i",
   "img",
   "link",
@@ -19,7 +19,7 @@ const parentNodeBlocklist: Node["nodeName"][] = [
   "svg",
   "textarea",
   "video",
-];
+]);
 
 const patternRegex: {
   [key in QueryPattern]: (query: string, flags?: string) => RegExp;
@@ -278,10 +278,11 @@ export function searchNode(
 
   if (
     element.nodeType === Node.TEXT_NODE &&
-    !parentNodeBlocklist.includes(
+    !element.parentElement?.dataset["isReplaced"] &&
+    !nodeNameBlocklist.has(
       String(element.parentNode?.nodeName.toLowerCase())
     ) &&
-    !element.parentElement?.dataset["isReplaced"]
+    !element.parentElement?.hasAttribute("contenteditable")
   ) {
     found.push(element as unknown as Text);
   }

--- a/packages/shared/src/replace.ts
+++ b/packages/shared/src/replace.ts
@@ -118,7 +118,7 @@ export function replace(
   replacement: string,
   startPosition: number = 0
 ) {
-  if (!element) return;
+  if (!element || !Boolean(replacement)) return;
 
   const { parentNode } = element;
 

--- a/packages/shared/src/replace.ts
+++ b/packages/shared/src/replace.ts
@@ -17,6 +17,7 @@ const parentNodeBlocklist: Node["nodeName"][] = [
   "script",
   "style",
   "svg",
+  "textarea",
   "video",
 ];
 

--- a/packages/shared/src/replace.ts
+++ b/packages/shared/src/replace.ts
@@ -27,7 +27,7 @@ const patternRegex: {
   default: (query) => new RegExp(query, "gi"),
   regex: (query, flags) => new RegExp(query, flags),
   wholeWord: (query, flags) =>
-    new RegExp(`(^|\\s)${escapeRegex(query)}($|\\s)`, flags),
+    new RegExp(`(?<![^\\W_])${escapeRegex(query)}(?![^\\W_])`, flags),
 };
 
 /**
@@ -187,7 +187,7 @@ export function replace(
           replaced = elementContents
             .replace(
               patternRegex[pattern](query, getRegexFlags(queryPatterns)),
-              () => getReplacementHTML(element, query, ` ${replacement} `)
+              () => getReplacementHTML(element, query, replacement)
             )
             .replace(/\s\s+/g, "")
             .trim();

--- a/packages/shared/src/storage.ts
+++ b/packages/shared/src/storage.ts
@@ -1,4 +1,4 @@
-import { Matcher, Storage, StorageKey, StorageVersionType } from "@worm/types";
+import { Matcher, Storage, StorageKey, StorageVersion } from "@worm/types";
 
 import { browser } from "./browser";
 import { logDebug } from "./logging";
@@ -13,7 +13,7 @@ const {
   storage: { sync },
 } = browser;
 
-export const CURRENT_STORAGE_VERSION: StorageVersionType = "1.0.0";
+export const CURRENT_STORAGE_VERSION: StorageVersion = "1.0.0";
 
 export const storageGet = sync.get;
 export const storageRemove = sync.remove;

--- a/packages/shared/src/storage.ts
+++ b/packages/shared/src/storage.ts
@@ -1,4 +1,4 @@
-import { Matcher, Storage, StorageKey } from "@worm/types";
+import { Matcher, Storage, StorageKey, StorageVersionType } from "@worm/types";
 
 import { browser } from "./browser";
 import { logDebug } from "./logging";
@@ -12,6 +12,8 @@ type StorageSetOptions = {
 const {
   storage: { sync },
 } = browser;
+
+export const CURRENT_STORAGE_VERSION: StorageVersionType = "1.0.0";
 
 export const storageGet = sync.get;
 export const storageRemove = sync.remove;

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -1,7 +1,8 @@
 import { z } from "zod";
 
-const allQueryPatterns = ["case", "default", "regex", "wholeWord"] as const;
-export const schemaVersions = [1] as const;
+const queryPatterns = ["case", "default", "regex", "wholeWord"] as const;
+const schemaVersions = [1] as const;
+const storageVersions = ["1.0.0"] as const;
 
 export type DomainEffect = "allow" | "deny";
 
@@ -15,7 +16,7 @@ export type Matcher = {
 
 export type PopupTab = "domains" | "options" | "rules" | "support";
 
-export type QueryPattern = (typeof allQueryPatterns)[number];
+export type QueryPattern = (typeof queryPatterns)[number];
 
 export type SchemaExport = SchemaVersion & {
   version: SchemaVersionType;
@@ -38,7 +39,9 @@ export type SchemaVersionType = (typeof schemaVersions)[number];
 
 export type Storage = Partial<{
   [key in StorageKey]: StorageKeyMap[key];
-}>;
+}> & {
+  storageVersion?: StorageVersionType;
+};
 
 export type StorageKey = keyof StorageKeyMap;
 
@@ -51,4 +54,7 @@ export type StorageKeyMap = {
     extensionEnabled: boolean;
     focusRule: Matcher["identifier"];
   };
+  storageVersion: StorageVersionType;
 };
+
+export type StorageVersionType = (typeof storageVersions)[number];

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -40,7 +40,7 @@ export type SchemaVersionType = (typeof schemaVersions)[number];
 export type Storage = Partial<{
   [key in StorageKey]: StorageKeyMap[key];
 }> & {
-  storageVersion?: StorageVersionType;
+  storageVersion?: StorageVersion;
 };
 
 export type StorageKey = keyof StorageKeyMap;
@@ -54,7 +54,7 @@ export type StorageKeyMap = {
     extensionEnabled: boolean;
     focusRule: Matcher["identifier"];
   };
-  storageVersion: StorageVersionType;
+  storageVersion: StorageVersion;
 };
 
-export type StorageVersionType = (typeof storageVersions)[number];
+export type StorageVersion = (typeof storageVersions)[number];

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -17,22 +17,6 @@ export type PopupTab = "domains" | "options" | "rules" | "support";
 
 export type QueryPattern = (typeof allQueryPatterns)[number];
 
-export type Storage = Partial<{
-  [key in StorageKey]: StorageKeyMap[key];
-}>;
-
-export type StorageKey = keyof StorageKeyMap;
-
-export type StorageKeyMap = {
-  domainList: string[];
-  matchers: Matcher[];
-  preferences: {
-    activeTab: PopupTab;
-    domainListEffect: DomainEffect;
-    extensionEnabled: boolean;
-  };
-};
-
 export type SchemaExport = SchemaVersion & {
   version: SchemaVersionType;
 };
@@ -51,3 +35,20 @@ export type SchemaVersion1 = {
 };
 
 export type SchemaVersionType = (typeof schemaVersions)[number];
+
+export type Storage = Partial<{
+  [key in StorageKey]: StorageKeyMap[key];
+}>;
+
+export type StorageKey = keyof StorageKeyMap;
+
+export type StorageKeyMap = {
+  domainList: string[];
+  matchers: Matcher[];
+  preferences: {
+    activeTab: PopupTab;
+    domainListEffect: DomainEffect;
+    extensionEnabled: boolean;
+    focusRule: Matcher["identifier"];
+  };
+};


### PR DESCRIPTION
## Major

- New feature to automatically create rules from selected text - Users may now create rules easier by selecting the text they want to replace, right clicking on it, and choosing "Replace '...'" from the context menu. An attempt is made to open the popup programmatically and focus the new rule's replacement input field. The `openPopup()` method is not widely-available yet so a fallback exists to just open a new window.
- No longer overwriting `textarea` values or elements with the [`contenteditable`](https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/contenteditable) attribute

## Minor

- Improves whole word matching by better targeting word boundaries
- Adds tests to make sure certain user input element values are not replaced - This includes `input`, `textarea` and any element that has the `contenteditable` attribute.
- Adds text wrapping to long queries
- Adds a new `storageVersion` to storage to begin keeping track of which version of storage the user is currently using - This will make future changes to storage structure easier by enabling a way of performing migrations.