### PR TITLE
chore(popup): move export links to storage root

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
     "name": "dan-lovelace",
     "url": "https://github.com/dan-lovelace/word-replacer-max"
   },
-  "version": "0.5.0",
+  "version": "0.6.0",
   "license": "GPL-3.0-or-later",
   "description": "A browser extension for replacing text on web pages",
   "type": "module",

--- a/packages/background/src/lib/storage.ts
+++ b/packages/background/src/lib/storage.ts
@@ -5,7 +5,7 @@ import {
   storageGetByKeys,
   storageSetByKeys,
 } from "@worm/shared";
-import { Matcher } from "@worm/types";
+import { Matcher, Storage } from "@worm/types";
 
 export async function initializeStorage() {
   const { storageVersion } = await storageGetByKeys(["storageVersion"]);
@@ -18,16 +18,22 @@ export async function initializeStorage() {
     // perform any necessary migrations before proceeding
   }
 
-  const { domainList, matchers, preferences } = await storageGetByKeys([
-    "domainList",
-    "matchers",
-    "preferences",
-  ]);
+  const { domainList, exportLinks, matchers, preferences } =
+    await storageGetByKeys([
+      "domainList",
+      "exportLinks",
+      "matchers",
+      "preferences",
+    ]);
+
+  const initialStorage: Storage = {};
 
   if (domainList === undefined) {
-    await storageSetByKeys({
-      domainList: ["docs.google.com", "github.com"],
-    });
+    initialStorage.domainList = ["docs.google.com", "github.com"];
+  }
+
+  if (exportLinks === undefined) {
+    initialStorage.exportLinks = [];
   }
 
   if (matchers === undefined) {
@@ -48,18 +54,17 @@ export async function initializeStorage() {
       },
     ];
 
-    await storageSetByKeys({ matchers: defaultMatchers });
+    initialStorage.matchers = defaultMatchers;
   }
 
   if (preferences === undefined) {
-    await storageSetByKeys({
-      preferences: {
-        activeTab: "rules",
-        domainListEffect: "deny",
-        exportLinks: [],
-        extensionEnabled: true,
-        focusRule: "",
-      },
-    });
+    initialStorage.preferences = {
+      activeTab: "rules",
+      domainListEffect: "deny",
+      extensionEnabled: true,
+      focusRule: "",
+    };
   }
+
+  await storageSetByKeys(initialStorage);
 }

--- a/packages/popup/src/components/export/ExportLinks.tsx
+++ b/packages/popup/src/components/export/ExportLinks.tsx
@@ -13,17 +13,9 @@ import { useToast } from "../../store/Toast";
 export default function ExportLink() {
   const [isClipboardCopyAllowed, setIsClipboardCopyAllowed] = useState(false);
   const {
-    storage: { preferences },
+    storage: { exportLinks },
   } = useConfig();
   const { showToast } = useToast();
-
-  const exportLinks = useMemo(
-    () =>
-      Boolean(preferences?.exportLinks?.length)
-        ? preferences?.exportLinks
-        : undefined,
-    [preferences]
-  );
 
   useEffect(() => {
     async function initCopyPermission() {
@@ -35,18 +27,12 @@ export default function ExportLink() {
 
   const handleClearExport =
     (identifier: ExportLinkType["identifier"]) => () => {
-      const exportIdx =
-        exportLinks?.findIndex((link) => link.identifier === identifier) ?? -1;
-      const newPreferences = Object.assign({}, preferences);
-
-      if (exportIdx < 0 || !newPreferences?.exportLinks) return;
-
-      newPreferences.exportLinks = newPreferences.exportLinks.filter(
+      const newExportLinks = [...(exportLinks ?? [])].filter(
         (link) => link.identifier !== identifier
       );
 
       storageSetByKeys({
-        preferences: newPreferences,
+        exportLinks: newExportLinks,
       });
     };
 

--- a/packages/popup/src/components/export/ExportModal.tsx
+++ b/packages/popup/src/components/export/ExportModal.tsx
@@ -47,7 +47,7 @@ function refineMatchers(
 
 export default function ExportModal() {
   const {
-    storage: { matchers, preferences },
+    storage: { exportLinks, matchers },
   } = useConfig();
   const [isLoading, setIsLoading] = useState(false);
   const [selectedRules, setSelectedRules] = useState<SelectedRule[]>();
@@ -157,26 +157,37 @@ export default function ExportModal() {
       });
     }
 
-    const newPreferences = Object.assign({}, preferences);
     const newExportLinks = [
-      ...(newPreferences.exportLinks || []),
+      ...(exportLinks || []),
       {
         identifier: new Date().getTime(),
         url: json.data.value.url,
       },
     ];
-    newPreferences.exportLinks = newExportLinks;
 
-    storageSetByKeys({
-      preferences: newPreferences,
-    });
-
-    stopExporting();
-    showToast({
-      children: (
-        <ToastMessage message={String(json.data?.message)} severity="success" />
-      ),
-    });
+    storageSetByKeys(
+      {
+        exportLinks: newExportLinks,
+      },
+      {
+        onError: (message) => {
+          showToast({
+            children: <ToastMessage message={message} severity="danger" />,
+          });
+        },
+        onSuccess: () => {
+          stopExporting();
+          showToast({
+            children: (
+              <ToastMessage
+                message="Success! Your link is ready on the Options page."
+                severity="success"
+              />
+            ),
+          });
+        },
+      }
+    );
   };
 
   const handleSelectAllChange = (

--- a/packages/shared/cypress/e2e/replace-all.cy.ts
+++ b/packages/shared/cypress/e2e/replace-all.cy.ts
@@ -3,293 +3,335 @@ import { replaceAll } from "@worm/shared/src/replace";
 import { selectors as s } from "../support/selectors";
 
 describe("replaceAll", () => {
-  it("includes 'title' elements in the head", () => {
-    cy.visitMock({
-      targetContents: "Lorem ipsum dolor",
-      titleContents: "Lorem ipsum dolor",
-    });
+  describe("default query pattern", () => {
+    it("includes 'title' elements in the head", () => {
+      cy.visitMock({
+        targetContents: "Lorem ipsum dolor",
+        titleContents: "Lorem ipsum dolor",
+      });
 
-    cy.document().then((document) => {
-      replaceAll(
-        [
-          {
-            active: true,
-            identifier: "ABCD-1234",
-            queries: ["ipsum"],
-            queryPatterns: [],
-            replacement: "sit",
-          },
-        ],
-        document
-      );
-
-      s.target().should("have.text", "Lorem sit dolor");
-      s.title().should("have.text", "Lorem sit dolor");
-    });
-  });
-
-  it("does not overwrite 'script' elements", () => {
-    const headScriptContents = `
-      function ipsum() {
-
-      }
-    `;
-    cy.visitMock({
-      bodyContents: `
-        <p data-testid="target">Lorem ipsum dolor</p>
-        <script data-testid="bodyScript">
-          const html = document.createElement("html");
-          html.innerHTML = "<body>Lorem ipsum dolor sit</body>";
-        </script>
-      `,
-      scriptContents: headScriptContents,
-      titleContents: "Lorem ipsum dolor",
-    });
-
-    cy.document().then((document) => {
-      replaceAll(
-        [
-          {
-            active: true,
-            identifier: "ABCD-1234",
-            queries: ["ipsum"],
-            queryPatterns: [],
-            replacement: "sit",
-          },
-        ],
-        document
-      );
-
-      s.script().should("have.text", headScriptContents);
-      s.target().should("have.text", "Lorem sit dolor");
-      s.title().should("have.text", "Lorem sit dolor");
-
-      cy.findByTestId("bodyScript").then(($bodyScript) => {
-        const target = $bodyScript.get(0);
-
-        const contents = target.textContent
-          ?.split("\n")
-          .map((l) => l?.trim())
-          .filter(Boolean);
-        cy.wrap(contents?.[0]).should(
-          "equal",
-          'const html = document.createElement("html");'
+      cy.document().then((document) => {
+        replaceAll(
+          [
+            {
+              active: true,
+              identifier: "ABCD-1234",
+              queries: ["ipsum"],
+              queryPatterns: [],
+              replacement: "sit",
+            },
+          ],
+          document
         );
-        cy.wrap(contents?.[1]).should(
-          "equal",
-          'html.innerHTML = "<body>Lorem ipsum dolor sit</body>";'
+
+        s.target().should("have.text", "Lorem sit dolor");
+        s.title().should("have.text", "Lorem sit dolor");
+      });
+    });
+
+    it("does not overwrite 'script' elements", () => {
+      const headScriptContents = `
+        function ipsum() {
+  
+        }
+      `;
+      cy.visitMock({
+        bodyContents: `
+          <p data-testid="target">Lorem ipsum dolor</p>
+          <script data-testid="bodyScript">
+            const html = document.createElement("html");
+            html.innerHTML = "<body>Lorem ipsum dolor sit</body>";
+          </script>
+        `,
+        scriptContents: headScriptContents,
+        titleContents: "Lorem ipsum dolor",
+      });
+
+      cy.document().then((document) => {
+        replaceAll(
+          [
+            {
+              active: true,
+              identifier: "ABCD-1234",
+              queries: ["ipsum"],
+              queryPatterns: [],
+              replacement: "sit",
+            },
+          ],
+          document
         );
+
+        s.script().should("have.text", headScriptContents);
+        s.target().should("have.text", "Lorem sit dolor");
+        s.title().should("have.text", "Lorem sit dolor");
+
+        cy.findByTestId("bodyScript").then(($bodyScript) => {
+          const target = $bodyScript.get(0);
+
+          const contents = target.textContent
+            ?.split("\n")
+            .map((l) => l?.trim())
+            .filter(Boolean);
+          cy.wrap(contents?.[0]).should(
+            "equal",
+            'const html = document.createElement("html");'
+          );
+          cy.wrap(contents?.[1]).should(
+            "equal",
+            'html.innerHTML = "<body>Lorem ipsum dolor sit</body>";'
+          );
+        });
+      });
+    });
+
+    it("does not overwrite surrounding children", () => {
+      cy.visitMock({
+        targetContents: `
+          <h3 class="h3-mktg mb-4 text-medium">
+            <span data-testid="span" class="text-accent-primary d-block">Lorem ipsum</span>
+            Sit dolor
+          </h3>
+        `,
+      });
+
+      cy.document().then((document) => {
+        replaceAll(
+          [
+            {
+              active: true,
+              identifier: "ABCD-1234",
+              queries: ["dolor"],
+              queryPatterns: [],
+              replacement: "sit",
+            },
+          ],
+          document
+        );
+
+        cy.findByTestId("span").should("have.text", "Lorem ipsum");
+      });
+    });
+
+    it("maintains text enhancement elements", () => {
+      cy.visitMock({
+        targetContents: "Lorem <u>ipsum</u> dolor",
+      });
+
+      cy.document().then((document) => {
+        replaceAll(
+          [
+            {
+              active: true,
+              identifier: "ABCD-1234",
+              queries: ["ipsum"],
+              queryPatterns: [],
+              replacement: "sit",
+            },
+          ],
+          document
+        );
+
+        cy.get("u").should("have.text", "sit");
+      });
+    });
+
+    it("does not match across element boundaries", () => {
+      cy.visitMock({
+        targetContents: "Lorem <u>ipsum</u> dolor",
+      });
+
+      cy.document().then((document) => {
+        replaceAll(
+          [
+            {
+              active: true,
+              identifier: "ABCD-1234",
+              queries: ["ipsum dolor"],
+              queryPatterns: [],
+              replacement: "sit",
+            },
+          ],
+          document
+        );
+
+        s.target().should("have.text", "Lorem ipsum dolor");
+      });
+    });
+
+    it("works for wikipedia", () => {
+      cy.visitMock({
+        html: "wiki.html",
+      });
+
+      cy.document().then((document) => {
+        replaceAll(
+          [
+            {
+              active: true,
+              identifier: "ABCD-1234",
+              queries: ["2014"],
+              queryPatterns: [],
+              replacement: "1979",
+            },
+          ],
+          document
+        );
+
+        cy.findByTestId("anchor1").should(
+          "have.text",
+          "1979 Commonwealth Games"
+        );
+        cy.findByTestId("anchor2").should(
+          "have.text",
+          "1979 ITU World Triathlon Series"
+        );
+        s.target().contains("from 1979 to 2016");
+      });
+    });
+
+    it("does not overwrite text input value", () => {
+      cy.visitMock({
+        bodyContents: `
+          <input data-testid="input-target" type="text" value="Lorem ipsum dolor"></input>
+          <div data-testid="target">Lorem ipsum dolor</div>
+        `,
+      });
+
+      cy.document().then((document) => {
+        replaceAll(
+          [
+            {
+              active: true,
+              identifier: "ABCD-1234",
+              queries: ["ipsum"],
+              queryPatterns: [],
+              replacement: "sit",
+            },
+          ],
+          document
+        );
+
+        cy.findByTestId("input-target").should(
+          "have.value",
+          "Lorem ipsum dolor"
+        );
+        s.target().should("have.text", "Lorem sit dolor");
+      });
+    });
+
+    it("does not overwrite textarea input value", () => {
+      cy.visitMock({
+        bodyContents: `
+          <textarea data-testid="input-target">Lorem ipsum dolor</textarea>
+          <div data-testid="target">Lorem ipsum dolor</div>
+        `,
+      });
+
+      cy.document().then((document) => {
+        replaceAll(
+          [
+            {
+              active: true,
+              identifier: "ABCD-1234",
+              queries: ["ipsum"],
+              queryPatterns: [],
+              replacement: "sit",
+            },
+          ],
+          document
+        );
+
+        cy.findByTestId("input-target").should(
+          "have.text",
+          "Lorem ipsum dolor"
+        );
+        s.target().should("have.text", "Lorem sit dolor");
+      });
+    });
+
+    it("does not overwrite elements that have the 'contenteditable' attribute", () => {
+      cy.visitMock({
+        bodyContents: `
+          <div data-testid="target" contenteditable>Lorem ipsum dolor</div>
+        `,
+      });
+
+      cy.document().then((document) => {
+        replaceAll(
+          [
+            {
+              active: true,
+              identifier: "ABCD-1234",
+              queries: ["ipsum"],
+              queryPatterns: [],
+              replacement: "sit",
+            },
+          ],
+          document
+        );
+
+        s.target().should("have.text", "Lorem ipsum dolor");
       });
     });
   });
 
-  it("does not overwrite surrounding children", () => {
-    cy.visitMock({
-      targetContents: `
-        <h3 class="h3-mktg mb-4 text-medium">
-          <span data-testid="span" class="text-accent-primary d-block">Lorem ipsum</span>
-          Sit dolor
-        </h3>
-      `,
-    });
-
-    cy.document().then((document) => {
-      replaceAll(
-        [
-          {
-            active: true,
-            identifier: "ABCD-1234",
-            queries: ["dolor"],
-            queryPatterns: [],
-            replacement: "sit",
-          },
-        ],
-        document
-      );
-
-      cy.findByTestId("span").should("have.text", "Lorem ipsum");
-    });
-  });
-
-  it("maintains text enhancement elements", () => {
-    cy.visitMock({
-      targetContents: "Lorem <u>ipsum</u> dolor",
-    });
-
-    cy.document().then((document) => {
-      replaceAll(
-        [
-          {
-            active: true,
-            identifier: "ABCD-1234",
-            queries: ["ipsum"],
-            queryPatterns: [],
-            replacement: "sit",
-          },
-        ],
-        document
-      );
-
-      cy.get("u").should("have.text", "sit");
-    });
-  });
-
-  it("does not match across element boundaries", () => {
-    cy.visitMock({
-      targetContents: "Lorem <u>ipsum</u> dolor",
-    });
-
-    cy.document().then((document) => {
-      replaceAll(
-        [
-          {
-            active: true,
-            identifier: "ABCD-1234",
-            queries: ["ipsum dolor"],
-            queryPatterns: [],
-            replacement: "sit",
-          },
-        ],
-        document
-      );
-
-      s.target().should("have.text", "Lorem ipsum dolor");
-    });
-  });
-
-  it("works for wikipedia", () => {
-    cy.visitMock({
-      html: "wiki.html",
-    });
-
-    cy.document().then((document) => {
-      replaceAll(
-        [
-          {
-            active: true,
-            identifier: "ABCD-1234",
-            queries: ["2014"],
-            queryPatterns: [],
-            replacement: "1979",
-          },
-        ],
-        document
-      );
-
-      cy.findByTestId("anchor1").should("have.text", "1979 Commonwealth Games");
-      cy.findByTestId("anchor2").should(
-        "have.text",
-        "1979 ITU World Triathlon Series"
-      );
-      s.target().contains("from 1979 to 2016");
-    });
-  });
-
-  it("works for regex negative lookaheads", () => {
-    cy.visitMock({
-      targetContents: `
+  describe("'regex' query pattern only", () => {
+    it("works for regex negative lookaheads", () => {
+      cy.visitMock({
+        targetContents: `
         <div data-testid="target-1">Hours: 7,5</div>
         <div data-testid="target-2">Hours: 8,55</div>
         <div data-testid="target-3">5Hours: 8,5Lorem</div>
       `,
-    });
+      });
 
-    cy.document().then((document) => {
-      replaceAll(
-        [
-          {
-            active: true,
-            identifier: "ABCD-1234",
-            queries: ["\\b(\\d+),5(?!\\d)"],
-            queryPatterns: ["regex"],
-            replacement: "$1,test",
-          },
-        ],
-        document
-      );
+      cy.document().then((document) => {
+        replaceAll(
+          [
+            {
+              active: true,
+              identifier: "ABCD-1234",
+              queries: ["\\b(\\d+),5(?!\\d)"],
+              queryPatterns: ["regex"],
+              replacement: "$1,test",
+            },
+          ],
+          document
+        );
 
-      cy.findByTestId("target-1").should("have.text", "Hours: 7,test");
-      cy.findByTestId("target-2").should("have.text", "Hours: 8,55");
-      cy.findByTestId("target-3").should("have.text", "5Hours: 8,testLorem");
-    });
-  });
-
-  it("does not overwrite text input value", () => {
-    cy.visitMock({
-      bodyContents: `
-        <input data-testid="input-target" type="text" value="Lorem ipsum dolor"></input>
-        <div data-testid="target">Lorem ipsum dolor</div>
-      `,
-    });
-
-    cy.document().then((document) => {
-      replaceAll(
-        [
-          {
-            active: true,
-            identifier: "ABCD-1234",
-            queries: ["ipsum"],
-            queryPatterns: [],
-            replacement: "sit",
-          },
-        ],
-        document
-      );
-
-      cy.findByTestId("input-target").should("have.value", "Lorem ipsum dolor");
-      s.target().should("have.text", "Lorem sit dolor");
+        cy.findByTestId("target-1").should("have.text", "Hours: 7,test");
+        cy.findByTestId("target-2").should("have.text", "Hours: 8,55");
+        cy.findByTestId("target-3").should("have.text", "5Hours: 8,testLorem");
+      });
     });
   });
 
-  it("does not overwrite textarea input value", () => {
-    cy.visitMock({
-      bodyContents: `
-        <textarea data-testid="input-target">Lorem ipsum dolor</textarea>
-        <div data-testid="target">Lorem ipsum dolor</div>
-      `,
-    });
+  describe("'wholeWord' query pattern only", () => {
+    it("does not remove empty space around sibling elements for 'wholeWord' pattern", () => {
+      cy.visitMock({
+        bodyContents: `
+          <p data-testid="target">
+            Lorem ipsum <a>dolor</a>.
+          </p>
+        `,
+      });
 
-    cy.document().then((document) => {
-      replaceAll(
-        [
-          {
-            active: true,
-            identifier: "ABCD-1234",
-            queries: ["ipsum"],
-            queryPatterns: [],
-            replacement: "sit",
-          },
-        ],
-        document
-      );
+      cy.document().then((document) => {
+        replaceAll(
+          [
+            {
+              active: true,
+              identifier: "ABCD-1234",
+              queries: ["ipsum"],
+              queryPatterns: ["wholeWord"],
+              replacement: "sit",
+            },
+          ],
+          document
+        );
 
-      cy.findByTestId("input-target").should("have.text", "Lorem ipsum dolor");
-      s.target().should("have.text", "Lorem sit dolor");
-    });
-  });
-
-  it("does not overwrite elements that have the 'contenteditable' attribute", () => {
-    cy.visitMock({
-      bodyContents: `
-        <div data-testid="target" contenteditable>Lorem ipsum dolor</div>
-      `,
-    });
-
-    cy.document().then((document) => {
-      replaceAll(
-        [
-          {
-            active: true,
-            identifier: "ABCD-1234",
-            queries: ["ipsum"],
-            queryPatterns: [],
-            replacement: "sit",
-          },
-        ],
-        document
-      );
-
-      s.target().should("have.text", "Lorem ipsum dolor");
+        s.target().should("include.text", "Lorem sit dolor.");
+      });
     });
   });
 });

--- a/packages/shared/src/replace.ts
+++ b/packages/shared/src/replace.ts
@@ -194,8 +194,7 @@ export function replace(
               patternRegex[pattern](query, getRegexFlags(queryPatterns)),
               () => getReplacementHTML(element, query, replacement)
             )
-            .replace(/\s\s+/g, "")
-            .trim();
+            .replace(/\s\s+/g, "");
           break;
         }
       }

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -60,11 +60,11 @@ export type StorageKey = keyof StorageKeyMap;
 
 export type StorageKeyMap = {
   domainList: string[];
+  exportLinks: ExportLink[];
   matchers: Matcher[];
   preferences: {
     activeTab: PopupTab;
     domainListEffect: DomainEffect;
-    exportLinks?: ExportLink[];
     extensionEnabled: boolean;
     focusRule: Matcher["identifier"];
   };


### PR DESCRIPTION
## Minor

- Moves the location of export links in storage to the root level
- Adds graceful handling of storage capacity errors when adding to export links