### PR TITLE
chore(github): add run-tests workflow dispatch

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -4,10 +4,23 @@ on:
   pull_request:
     paths:
       - packages/**
+  workflow_dispatch:
+    inputs:
+      environment:
+        default: test
+        description: "Which .env config to use"
+        required: true
+        type: choice
+        options:
+          - development
+          - production
+          - test
 
 jobs:
   test:
     runs-on: ubuntu-latest
+    env:
+      VITE_MODE: ${{ inputs.environment }}
 
     steps:
       - uses: actions/checkout@v4

--- a/packages/popup/package.json
+++ b/packages/popup/package.json
@@ -8,7 +8,7 @@
     "build": "tsc && vite build",
     "cypress:open": "cypress open --e2e --browser chrome",
     "cypress:run": "cypress run",
-    "dev": "vite --host --mode test",
+    "dev": "vite --host --mode ${VITE_MODE:-test}",
     "start": "yarn build --watch --mode development",
     "test": "echo \"Error: no test specified\" && exit 0"
   },

--- a/packages/popup/src/components/export/ExportLinks.tsx
+++ b/packages/popup/src/components/export/ExportLinks.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useState } from "preact/hooks";
+import { useEffect, useState } from "preact/hooks";
 
 import { formatUnixTimestamp, storageSetByKeys } from "@worm/shared";
 import { ExportLink as ExportLinkType } from "@worm/types";


### PR DESCRIPTION
## Minor

- Updates the `run-tests` workflow to support manual dispatch against any target API environment