### PR TITLE
feat(replace): include idiomatic text elements

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
     "name": "dan-lovelace",
     "url": "https://github.com/dan-lovelace/word-replacer-max"
   },
-  "version": "0.7.0",
+  "version": "0.7.1",
   "license": "GPL-3.0-or-later",
   "description": "A browser extension for replacing text on web pages",
   "type": "module",

--- a/packages/shared/cypress/e2e/replace-all.cy.ts
+++ b/packages/shared/cypress/e2e/replace-all.cy.ts
@@ -168,6 +168,31 @@ describe("replaceAll", () => {
       });
     });
 
+    it("replaces idiomatic text elements", () => {
+      cy.visitMock({
+        targetContents: "Lorem <i>ipsum</i> dolor",
+      });
+
+      cy.document().then((document) => {
+        replaceAll(
+          [
+            {
+              active: true,
+              identifier: "ABCD-1234",
+              queries: ["ipsum"],
+              queryPatterns: [],
+              replacement: "sit",
+              useGlobalReplacementStyle: true,
+            },
+          ],
+          undefined,
+          document
+        );
+
+        cy.get("i").should("have.text", "sit");
+      });
+    });
+
     it("works for wikipedia", () => {
       cy.visitMock({
         html: "wiki.html",

--- a/packages/shared/src/replace/lib/dom.ts
+++ b/packages/shared/src/replace/lib/dom.ts
@@ -3,7 +3,6 @@ import { Matcher, ReplacementStyle } from "@worm/types";
 import { CONTENTS_PROPERTY, REPLACEMENT_WRAPPER_ELEMENT } from ".";
 
 export const nodeNameBlocklist: Set<Node["nodeName"]> = new Set([
-  "i",
   "img",
   "link",
   "meta",


### PR DESCRIPTION
## Breaking changes

- Removes `<i>` elements from the replacement block list - This has the potential to create issues when developers misuse the `i` element for icons.