### PR TITLE
feat(shared): support vue ssr comment markers during replacement

### DIFF
--- a/packages/shared/src/replace/lib/dom.ts
+++ b/packages/shared/src/replace/lib/dom.ts
@@ -1,4 +1,4 @@
-import { Matcher, ReplacementStyle } from "@worm/types";
+import { Matcher, ReplacementStyle, VueNodeInfo } from "@worm/types";
 
 import { CONTENTS_PROPERTY, REPLACEMENT_WRAPPER_ELEMENT } from "./";
 
@@ -62,7 +62,7 @@ export function styleReplacement(
 /**
  * Creates a temporary element and injects the replaced text string as HTML.
  * The replacement HTML string comes in looking like this:
- * `Lorem <span>ipsum</span> dolor`.  It's then converted to an array of child
+ * `Lorem <span>ipsum</span> dolor`. It's then converted to an array of child
  * nodes consisting of at least one Text node and one element wrapping the
  * replacement text. The array is spread into a fragment which is then used to
  * replace the original Text node entirely.
@@ -72,12 +72,101 @@ export function replaceTextNode(element: Text, html: string) {
 
   if (!parentNode) return;
 
+  const parentElement = parentNode as HTMLElement;
+
+  const vueInfo = getVueNodeInfo(element);
+  if (vueInfo.isVueManaged) {
+    return replaceVueNode(vueInfo, parentElement, element, html);
+  }
+
   const wrapper = document.createElement(REPLACEMENT_WRAPPER_ELEMENT);
   wrapper.innerHTML = html;
 
   const fragment = document.createDocumentFragment();
   fragment.append(...wrapper.childNodes);
 
-  const parentElement = parentNode as HTMLElement;
+  parentElement.replaceChild(fragment, element);
+}
+
+/**
+ * Detects if a node is managed by Vue by checking for SSR comment markers.
+ */
+export function getVueNodeInfo(node: Node): VueNodeInfo {
+  const markers: Comment[] = [];
+  let current: Node | null = node;
+
+  // check immediate siblings for vue comment markers
+  while (current) {
+    if (current.nodeType === Node.COMMENT_NODE) {
+      const comment = current as Comment;
+
+      if (comment.textContent === "[" || comment.textContent === "]") {
+        markers.push(comment);
+      }
+    }
+
+    current = current.previousSibling;
+  }
+
+  current = node.nextSibling;
+  while (current) {
+    if (current.nodeType === Node.COMMENT_NODE) {
+      const comment = current as Comment;
+
+      if (comment.textContent === "[" || comment.textContent === "]") {
+        markers.push(comment);
+      }
+    }
+
+    current = current.nextSibling;
+  }
+
+  return {
+    isVueManaged: markers.length > 0,
+    commentMarkers: markers,
+  };
+}
+
+/**
+ * Replaces a node managed by Vue. It performs replacements while preserving
+ * SSR comment markers.
+ *
+ * @see https://github.com/dan-lovelace/word-replacer-max/issues/31
+ */
+export function replaceVueNode(
+  vueInfo: VueNodeInfo,
+  parentElement: HTMLElement,
+  element: Text,
+  html: string
+) {
+  const wrapper = document.createElement(REPLACEMENT_WRAPPER_ELEMENT);
+  wrapper.innerHTML = html;
+
+  const fragment = document.createDocumentFragment();
+
+  // preserve any leading vue comments
+  const previousComments = Array.from(vueInfo.commentMarkers).filter(
+    (comment) =>
+      element.compareDocumentPosition(comment) &
+      Node.DOCUMENT_POSITION_PRECEDING
+  );
+  previousComments.forEach((comment) => {
+    fragment.appendChild(comment.cloneNode(true));
+  });
+
+  // add replaced content
+  fragment.append(...wrapper.childNodes);
+
+  // preserve any trailing vue comments
+  const followingComments = Array.from(vueInfo.commentMarkers).filter(
+    (comment) =>
+      element.compareDocumentPosition(comment) &
+      Node.DOCUMENT_POSITION_FOLLOWING
+  );
+  followingComments.forEach((comment) => {
+    fragment.appendChild(comment.cloneNode(true));
+  });
+
+  // replace the original element with new fragment
   parentElement.replaceChild(fragment, element);
 }

--- a/packages/shared/src/replace/replace-text.ts
+++ b/packages/shared/src/replace/replace-text.ts
@@ -1,8 +1,10 @@
 import { Matcher, MatcherReplaceProps, ReplacementStyle } from "@worm/types";
 
 import {
-  CONTENTS_PROPERTY, getSortedQueryPatterns, isReplacementEmpty,
-  REPLACEMENT_WRAPPER_ELEMENT
+  CONTENTS_PROPERTY,
+  getSortedQueryPatterns,
+  isReplacementEmpty,
+  REPLACEMENT_WRAPPER_ELEMENT,
 } from "./lib";
 import { getReplacementHTML, replaceTextNode } from "./lib/dom";
 import { getRegexFlags, patternRegex, regExpReplace } from "./lib/regex";

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -126,4 +126,9 @@ export type SystemColor =
   | "white"
   | "yellow";
 
+export type VueNodeInfo = {
+  commentMarkers: Comment[];
+  isVueManaged: boolean;
+};
+
 export * from "./api";


### PR DESCRIPTION
## Minor

- Preserves VueJS comment markers when replacing to prevent content duplication - Resolves #31

## Assets

![Screenshot 2024-11-08 at 6 11 25 PM](https://github.com/user-attachments/assets/8c456b10-a158-48fc-ba1f-7c0d02f82756)
