### PR TITLE
fix(background): users are logged out when closing their browser

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,6 +25,6 @@
     "write-config": "tsx scripts/src/write-config.ts"
   },
   "engines": {
-    "node": ">=18.0.0"
+    "node": ">=20.0.0"
   }
 }

--- a/packages/background/src/lib/auth/session-store.ts
+++ b/packages/background/src/lib/auth/session-store.ts
@@ -8,8 +8,6 @@ type StorageAuthKey = (typeof storageAuthSuffixes)[number];
 const envConfig = getEnvConfig();
 const userPoolClientId = envConfig.VITE_SSM_USER_POOL_CLIENT_ID;
 
-const sessionStorageProvider = getStorageProvider("session");
-
 /**
  * These are the suffixes of storage keys used by Amplify when getting/setting.
  * There are others not currently in use; this list is non-exhaustive:
@@ -29,6 +27,8 @@ const storageAuthSuffixes = [
 ] as const;
 
 const storageAuthKeyPrefix = `CognitoIdentityServiceProvider.${userPoolClientId}`;
+
+export const sessionStorageProvider = getStorageProvider("local");
 
 export const sessionStorageInterface: KeyValueStorageInterface = {
   clear: () =>

--- a/packages/background/src/lib/messages.ts
+++ b/packages/background/src/lib/messages.ts
@@ -7,7 +7,6 @@ import {
 } from "@worm/shared";
 import { getApiEndpoint } from "@worm/shared/src/api";
 import { browser } from "@worm/shared/src/browser";
-import { getStorageProvider } from "@worm/shared/src/storage";
 import { ApiAuthTokens } from "@worm/types/src/api";
 import { IdentificationError } from "@worm/types/src/identity";
 import {
@@ -20,6 +19,7 @@ import {
 import { UserTokens } from "@worm/types/src/permission";
 
 import { getAuthTokens, getCurrentUser, signUserOut } from "./auth/session";
+import { sessionStorageProvider } from "./auth/session-store";
 
 function getError(error: unknown) {
   let errorMessage: string;
@@ -218,7 +218,7 @@ export function startMessageListener() {
              * Update storage using our own keys, not Amplify's. These are
              * translated in the custom token provider.
              */
-            await getStorageProvider("session").set({
+            await sessionStorageProvider.set({
               authAccessToken: tokens.accessToken,
               authIdToken: tokens.idToken,
               authLastAuthUser: decodeJWT(

--- a/packages/popup/cypress/support/cmd/login.ts
+++ b/packages/popup/cypress/support/cmd/login.ts
@@ -1,8 +1,8 @@
 import { API_ROUTES } from "@worm/types/src/api";
 import { UserTokens } from "@worm/types/src/permission";
-import { SessionStorage } from "@worm/types/src/storage";
+import { LocalStorage } from "@worm/types/src/storage";
 
-const cache: Partial<{ sessionStore: SessionStorage }> = {
+const cache: Partial<{ sessionStore: LocalStorage }> = {
   sessionStore: undefined,
 };
 
@@ -13,13 +13,13 @@ Cypress.Commands.add("appUserLogin", () => {
   cy.wrap(null).then(async () => {
     const updateStorageTokens = (tokens: UserTokens) => {
       cy.getBrowser().then((browser) => {
-        const sessionStore: SessionStorage = {
+        const sessionStore: LocalStorage = {
           authAccessToken: tokens.accessToken,
           authIdToken: tokens.idToken,
           authLastAuthUser: username,
         };
 
-        browser.storage?.session?.set(sessionStore).then(() => {
+        browser.storage?.local?.set(sessionStore).then(() => {
           cache.sessionStore = sessionStore;
         });
       });

--- a/packages/popup/cypress/support/interceptors/contact.ts
+++ b/packages/popup/cypress/support/interceptors/contact.ts
@@ -6,7 +6,7 @@ export function interceptContactSupport(
   responseOverrides?: Partial<CyHttpMessages.IncomingHttpResponse<any>>
 ) {
   cy.getBrowser().then(async (browser) => {
-    const authAccessToken = (await browser.storage.session?.get())
+    const authAccessToken = (await browser.storage.local?.get())
       ?.authAccessToken;
 
     cy.intercept("POST", ENDPOINTS.CONTACT_SUPPORT, (request) => {

--- a/packages/popup/cypress/support/interceptors/suggest.ts
+++ b/packages/popup/cypress/support/interceptors/suggest.ts
@@ -2,7 +2,7 @@ import { ENDPOINTS } from "../endpoints";
 
 export function interceptSuggest() {
   cy.getBrowser().then(async (browser) => {
-    const authAccessToken = (await browser.storage.session?.get())
+    const authAccessToken = (await browser.storage.local?.get())
       ?.authAccessToken;
 
     cy.intercept(ENDPOINTS.SUGGEST, (request) => {

--- a/packages/popup/src/store/Auth.tsx
+++ b/packages/popup/src/store/Auth.tsx
@@ -27,7 +27,7 @@ export const useAuth = () => useContext(Auth);
 export function AuthProvider({ children }: { children: PreactChildren }) {
   const {
     storage: {
-      session: { authIdToken, authLastAuthUser },
+      local: { authIdToken, authLastAuthUser },
     },
   } = useConfig();
 

--- a/packages/popup/src/store/Config.tsx
+++ b/packages/popup/src/store/Config.tsx
@@ -23,14 +23,14 @@ type ConfigStore = {
 const storeDefaults: ConfigStore = {
   isPoppedOut: false,
   storage: {
-    local: {},
-    session: {
+    local: {
       authAccessToken: undefined,
       authClockDrift: undefined,
       authIdToken: undefined,
       authLastAuthUser: undefined,
       authRefreshToken: undefined,
     },
+    session: {},
     sync: {
       domainList: [],
       matchers: [],

--- a/packages/types/src/storage.ts
+++ b/packages/types/src/storage.ts
@@ -12,6 +12,16 @@ export const storageVersions = ["1.0.0", "1.1.0", "1.1.1"] as const;
 
 export type LocalStorage = Partial<{
   recentSuggestions: RecentSuggestions;
+
+  /**
+   * Auth keys are mapped using their respective names from Amplify. A custom
+   * token provider exists to translate Amplify's version to our own.
+   */
+  authAccessToken: string;
+  authClockDrift: string;
+  authLastAuthUser: string;
+  authIdToken: string;
+  authRefreshToken: string;
 }>;
 
 /**
@@ -56,17 +66,7 @@ export type SchemaVersion1 = {
 
 export type SchemaVersionType = (typeof schemaVersions)[number];
 
-export type SessionStorage = Partial<{
-  /**
-   * Auth keys are mapped using their respective names from Amplify. A custom
-   * token provider exists to translate Amplify's version to our own.
-   */
-  authAccessToken: string;
-  authClockDrift: string;
-  authLastAuthUser: string;
-  authIdToken: string;
-  authRefreshToken: string;
-}>;
+export type SessionStorage = Partial<{}>;
 
 export type Storage = {
   local: LocalStorage;


### PR DESCRIPTION
## Minor

- Moves auth token storage away from `storage.session` to `storage.local` to allow persistence between browser restarts
- Bumps the minimum required Node version for dependency installation