### PR TITLE
refactor(scripts): replace tabs permission with activeTab

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
     "name": "Dan Lovelace",
     "url": "https://github.com/dan-lovelace/word-replacer-max"
   },
-  "version": "0.9.0",
+  "version": "0.9.1",
   "license": "GPL-3.0-or-later",
   "description": "A browser extension for replacing text on web pages",
   "type": "module",

--- a/packages/webapp/src/components/header/LayoutHeader.tsx
+++ b/packages/webapp/src/components/header/LayoutHeader.tsx
@@ -60,7 +60,6 @@ export default function LayoutHeader() {
                 sx={{
                   display: { xs: "none", md: "block" },
                   fontWeight: "bold",
-                  marginTop: "2px",
                   userSelect: "none",
                 }}
               >

--- a/packages/webapp/src/pages/HomePage.tsx
+++ b/packages/webapp/src/pages/HomePage.tsx
@@ -75,7 +75,7 @@ export default function HomePage() {
                 fontWeight: 600,
               }}
             >
-              Make the web speak your language
+              Your web, your words
             </Typography>
             <Container>
               <Typography

--- a/scripts/src/lib/manifest.ts
+++ b/scripts/src/lib/manifest.ts
@@ -142,5 +142,13 @@ export async function getManifest(version: number): Promise<Manifest> {
       ];
   }
 
+  /**
+   * Validate resolved manifest.
+   */
+  assert(
+    !manifestBase.permissions?.includes("tabs"),
+    "Manifest permissions may not contain 'tabs' because the extension will prompt for browsing history access"
+  );
+
   return manifestBase;
 }

--- a/scripts/src/lib/manifest.ts
+++ b/scripts/src/lib/manifest.ts
@@ -21,7 +21,7 @@ const commonProps: ManifestBase = {
   },
   manifest_version: 0,
   name: "Word Replacer Max",
-  permissions: ["contextMenus", "storage", "tabs"],
+  permissions: ["activeTab", "contextMenus", "storage"],
   version: "",
 };
 


### PR DESCRIPTION
## Minor

- Replaces the `tabs` permission with `activeTab` to avoid prompting for unnecessary permissions
- Adds a validation check to the `manifest` script that will throw if `tabs` is ever re-added to permissions at a later time