### PR TITLE
feat(popup): bulk rule paste and csv import

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
     "name": "Dan Lovelace",
     "url": "https://github.com/dan-lovelace/word-replacer-max"
   },
-  "version": "0.9.1",
+  "version": "0.9.3",
   "license": "GPL-3.0-or-later",
   "description": "A browser extension for replacing text on web pages",
   "type": "module",

--- a/packages/popup/cypress/e2e/home-page/rules.cy.ts
+++ b/packages/popup/cypress/e2e/home-page/rules.cy.ts
@@ -1,3 +1,5 @@
+import { QUERY_PASTE_DELIMITER } from "@worm/shared/src/strings";
+
 import {
   TEST_MATCHER_ID_1,
   TEST_MATCHER_ID_2,
@@ -58,6 +60,60 @@ describe("rules", () => {
 
           cy.wrap(matchers?.[0]).should("have.property", "active", false);
           cy.wrap(matchers?.[1]).should("have.property", "active", true);
+        });
+      });
+    });
+
+    describe("query input", () => {
+      describe("paste", () => {
+        const navigateAndPaste = (pasteValue: string, holdShift = false) => {
+          cy.visitWithStorage();
+
+          s.addNewRuleButton().click();
+
+          s.ruleRows()
+            .last()
+            .within(() => {
+              s.rules.queryInput
+                .input()
+                .focus()
+                .paste(pasteValue, { holdShift });
+            });
+        };
+
+        it("does not add queries when no delimiters exist", () => {
+          navigateAndPaste("lorem");
+
+          s.ruleRows()
+            .last()
+            .within(() => {
+              s.rules.queryInput.chips().should("have.length", 0);
+            });
+        });
+
+        it("does not add queries when a delimiter exists and the shift key is held", () => {
+          navigateAndPaste(`lorem${QUERY_PASTE_DELIMITER}ipsum`, true);
+
+          s.ruleRows()
+            .last()
+            .within(() => {
+              s.rules.queryInput.chips().should("have.length", 0);
+            });
+        });
+
+        it("adds queries when a delimiter exists", () => {
+          navigateAndPaste(`lorem${QUERY_PASTE_DELIMITER}ipsum`);
+
+          s.ruleRows()
+            .last()
+            .within(() => {
+              s.rules.queryInput.chips().then((chips) => {
+                expect(chips.length).to.eq(2);
+
+                cy.contains("lorem");
+                cy.contains("ipsum");
+              });
+            });
         });
       });
     });

--- a/packages/popup/cypress/e2e/options-page/rules-export.cy.ts
+++ b/packages/popup/cypress/e2e/options-page/rules-export.cy.ts
@@ -7,7 +7,7 @@ const { exportModal } = s;
 
 const MODAL_WAIT_PERIOD_MS = 500;
 
-describe("export", () => {
+describe("rules export", () => {
   beforeEach(() => {
     cy.visitWithStorage();
     s.optionsTab().click();

--- a/packages/popup/cypress/e2e/options-page/rules-import.cy.ts
+++ b/packages/popup/cypress/e2e/options-page/rules-import.cy.ts
@@ -12,25 +12,29 @@ describe("rules import", () => {
 
     s.layout.tabs.rules().click();
     s.ruleRows().then((ruleRows) => {
+      expect(ruleRows.length).to.eq(4);
+
       const thirdRow = ruleRows.eq(2);
       const fourthRow = ruleRows.eq(3);
 
       cy.wrap(thirdRow).within(() => {
         s.rules.queryInput.chips().then((chips) => {
-          expect(chips.length).to.eq(2);
+          expect(chips.length).to.eq(3);
 
-          cy.contains("lorem");
-          cy.contains("ipsum");
+          cy.contains("Word1");
+          cy.contains("Word2, Word3");
+          cy.contains("Word4");
         });
       });
 
       cy.wrap(fourthRow).within(() => {
         s.rules.queryInput.chips().then((chips) => {
-          expect(chips.length).to.eq(3);
+          expect(chips.length).to.eq(4);
 
-          cy.contains("lorem, ipsum");
-          cy.contains("sit");
-          cy.contains("dolor");
+          cy.contains("Word5");
+          cy.contains("Word6");
+          cy.contains("Word7");
+          cy.contains("Word8");
         });
       });
     });

--- a/packages/popup/cypress/e2e/options-page/rules-import.cy.ts
+++ b/packages/popup/cypress/e2e/options-page/rules-import.cy.ts
@@ -1,0 +1,48 @@
+import { selectors as s } from "../../support/selectors";
+
+describe("rules import", () => {
+  beforeEach(() => {
+    cy.visitWithStorage();
+    s.optionsTab().click();
+  });
+
+  it("should add rules from a csv file", () => {
+    cy.fixture("rules-import.csv", null).as("rulesImport");
+    s.options.rulesImport.label().selectFile("@rulesImport");
+
+    s.layout.tabs.rules().click();
+    s.ruleRows().then((ruleRows) => {
+      const thirdRow = ruleRows.eq(2);
+      const fourthRow = ruleRows.eq(3);
+
+      cy.wrap(thirdRow).within(() => {
+        s.rules.queryInput.chips().then((chips) => {
+          expect(chips.length).to.eq(2);
+
+          cy.contains("lorem");
+          cy.contains("ipsum");
+        });
+      });
+
+      cy.wrap(fourthRow).within(() => {
+        s.rules.queryInput.chips().then((chips) => {
+          expect(chips.length).to.eq(3);
+
+          cy.contains("lorem, ipsum");
+          cy.contains("sit");
+          cy.contains("dolor");
+        });
+      });
+    });
+  });
+
+  it("should not add rules from an empty csv file", () => {
+    cy.fixture("empty-rules-import.csv").as("emptyRulesImport");
+    s.options.rulesImport.label().selectFile("@emptyRulesImport");
+
+    s.layout.tabs.rules().click();
+    s.ruleRows().then((ruleRows) => {
+      expect(ruleRows.length).to.eq(2);
+    });
+  });
+});

--- a/packages/popup/cypress/e2e/options-page/rules-import.cy.ts
+++ b/packages/popup/cypress/e2e/options-page/rules-import.cy.ts
@@ -7,7 +7,7 @@ describe("rules import", () => {
   });
 
   it("should add rules from a csv file", () => {
-    cy.fixture("rules-import.csv", null).as("rulesImport");
+    cy.fixture("rules-import.csv").as("rulesImport");
     s.options.rulesImport.label().selectFile("@rulesImport");
 
     s.layout.tabs.rules().click();

--- a/packages/popup/cypress/fixtures/rules-import.csv
+++ b/packages/popup/cypress/fixtures/rules-import.csv
@@ -1,2 +1,3 @@
-lorem,ipsum,
-"lorem, ipsum",sit,dolor
+,,,,,,
+Word1,"Word2, Word3",Word4,,,,
+Word5,Word6,Word7,Word8,,,

--- a/packages/popup/cypress/fixtures/rules-import.csv
+++ b/packages/popup/cypress/fixtures/rules-import.csv
@@ -1,0 +1,2 @@
+lorem,ipsum,
+"lorem, ipsum",sit,dolor

--- a/packages/popup/cypress/support/cmd/index.ts
+++ b/packages/popup/cypress/support/cmd/index.ts
@@ -1,3 +1,4 @@
 import "./browser";
 import "./login";
+import "./paste";
 import "./visit";

--- a/packages/popup/cypress/support/cmd/paste.ts
+++ b/packages/popup/cypress/support/cmd/paste.ts
@@ -1,0 +1,41 @@
+Cypress.Commands.add(
+  "paste",
+  { prevSubject: true },
+  (selector, pastePayload, options = {}) => {
+    const pasteEvent = Object.assign(
+      new Event("paste", { bubbles: true, cancelable: true }),
+      {
+        clipboardData: {
+          getData: () => pastePayload,
+        },
+      }
+    );
+
+    return cy.wrap(selector).then((element) => {
+      return cy.window().then((win) => {
+        if (options.holdShift) {
+          const shiftDown = new KeyboardEvent("keydown", {
+            key: "Shift",
+            shiftKey: true,
+            bubbles: true,
+          });
+          win.document.documentElement.dispatchEvent(shiftDown);
+
+          // wait a tick to ensure state is updated
+          return cy.wrap(null).then(() => {
+            element[0].dispatchEvent(pasteEvent);
+
+            const shiftUp = new KeyboardEvent("keyup", {
+              key: "Shift",
+              shiftKey: false,
+              bubbles: true,
+            });
+            win.document.documentElement.dispatchEvent(shiftUp);
+          });
+        } else {
+          element[0].dispatchEvent(pasteEvent);
+        }
+      });
+    });
+  }
+);

--- a/packages/popup/cypress/support/commands.ts
+++ b/packages/popup/cypress/support/commands.ts
@@ -9,9 +9,13 @@ import { VisitWithStorageParams } from "./types";
 
 declare global {
   namespace Cypress {
-    interface Chainable {
+    interface Chainable<Subject = any> {
       appUserLogin(): Chainable<void>;
       getBrowser(): Chainable<TestBrowser<Storage>>;
+      paste(
+        value: string,
+        options?: Partial<{ holdShift: boolean }>
+      ): Chainable<Subject>;
       visitWithStorage(params?: VisitWithStorageParams): Chainable<void>;
     }
 

--- a/packages/popup/cypress/support/selectors.ts
+++ b/packages/popup/cypress/support/selectors.ts
@@ -83,6 +83,11 @@ export const selectors = {
       toggleButton: () =>
         cy.findByTestId("replacement-suggestions-toggle-button"),
     },
+    rulesImport: {
+      input: () => cy.findByTestId("file-input__input"),
+      label: () => cy.findByTestId("file-input__label"),
+      uploadRedirect: () => cy.findByTestId("file-input__upload-redirect"),
+    },
   },
   replacementStyles: {
     colorInputs: {
@@ -116,6 +121,11 @@ export const selectors = {
     list: {
       emptyRulesListAlert: () => cy.findByTestId("empty-rules-list-alert"),
       replacementInput: () => cy.findByTestId("replacement-text-input"),
+    },
+    queryInput: {
+      chips: () => cy.findAllByTestId("query-input__chip"),
+      input: () => cy.findByTestId("query-input__input"),
+      root: () => cy.findByTestId("query-input"),
     },
     replacementSuggest: {
       dropdownMenu: {

--- a/packages/popup/src/components/Chip.tsx
+++ b/packages/popup/src/components/Chip.tsx
@@ -1,9 +1,11 @@
+import { ComponentProps } from "preact";
+
 import { cx } from "@worm/shared";
 
 import Button from "./button/Button";
 import MaterialIcon from "./icon/MaterialIcon";
 
-type ChipProps = {
+type ChipProps = ComponentProps<"span"> & {
   disabled?: boolean;
   identifier: string;
   onRemove: (identifier: string) => () => void;
@@ -13,6 +15,7 @@ export default function Chip({
   disabled = false,
   identifier,
   onRemove,
+  ...rest
 }: ChipProps) {
   return (
     <span
@@ -21,6 +24,7 @@ export default function Chip({
         "d-flex align-items-center flex-fill-0 pe-0",
         "fs-6 text-bg-light text-start text-wrap"
       )}
+      {...rest}
     >
       {identifier}
       <Button

--- a/packages/popup/src/components/FileInput.tsx
+++ b/packages/popup/src/components/FileInput.tsx
@@ -6,7 +6,7 @@ import { POPUP_ROUTES } from "@worm/shared/src/browser";
 import { useLanguage } from "../lib/language";
 import {
   CAN_UPLOAD_PARAMETER,
-  canUploadDirect,
+  getCanUploadDirect,
   NOTIFY_PARAMETER,
 } from "../lib/routes";
 
@@ -28,20 +28,27 @@ function Content() {
 }
 
 export default function FileInput({ onChange }: FileUploadProps) {
-  const _canUploadDirect = useMemo(canUploadDirect, []);
+  const canUploadDirect = useMemo(getCanUploadDirect, []);
   const language = useLanguage();
   const message = encodeURIComponent(language.options.DIRECT_UPLOAD_DISALLOWED);
 
-  return _canUploadDirect ? (
-    <label className={WRAPPER_CLASSNAME}>
+  return canUploadDirect ? (
+    <label className={WRAPPER_CLASSNAME} data-testid="file-input__label">
       <Content />
-      <input accept=".json" hidden type="file" onChange={onChange} />
+      <input
+        accept=".json,.csv"
+        hidden
+        type="file"
+        onChange={onChange}
+        data-testid="file-input__input"
+      />
     </label>
   ) : (
     <a
       className={WRAPPER_CLASSNAME}
       href={`${POPUP_ROUTES.HOME}?${CAN_UPLOAD_PARAMETER}=true&${NOTIFY_PARAMETER}=${message}`}
       target="_blank"
+      data-testid="file-input__upload-redirect"
     >
       <Content />
     </a>

--- a/packages/popup/src/components/import/FileImport.tsx
+++ b/packages/popup/src/components/import/FileImport.tsx
@@ -1,8 +1,8 @@
 import type { JSXInternal } from "preact/src/jsx";
 
-import { logDebug } from "@worm/shared";
+import { getFileExtension, logDebug } from "@worm/shared";
 
-import importMatchers from "../../lib/import";
+import { importMatchersCSV, importMatchersJSON } from "../../lib/import";
 import { useLanguage } from "../../lib/language";
 import { useConfig } from "../../store/Config";
 
@@ -33,11 +33,29 @@ export default function FileImport() {
 
     fileReader.onloadend = async () => {
       const { result } = fileReader;
+      const extension = getFileExtension(file);
+
+      if (extension === "csv") {
+        return importMatchersCSV(result, matchers, {
+          onError(message) {
+            showToast({
+              message,
+              options: { severity: "danger" },
+            });
+          },
+          onSuccess() {
+            showToast({
+              message: language.options.FILE_IMPORT_SUCCESS,
+              options: { severity: "success" },
+            });
+          },
+        });
+      }
 
       try {
         const parsedJson = JSON.parse(String(result));
 
-        importMatchers(parsedJson, matchers, {
+        importMatchersJSON(parsedJson, matchers, {
           onError: (message) => {
             showToast({
               message,

--- a/packages/popup/src/components/import/LinkImport.tsx
+++ b/packages/popup/src/components/import/LinkImport.tsx
@@ -3,7 +3,7 @@ import { JSXInternal } from "preact/src/jsx";
 
 import { logDebug } from "@worm/shared";
 
-import importMatchers from "../../lib/import";
+import { importMatchersJSON } from "../../lib/import";
 import { useLanguage } from "../../lib/language";
 import { useConfig } from "../../store/Config";
 
@@ -61,7 +61,7 @@ export default function LinkImport({ setIsImportingLink }: LinkImportProps) {
         throw new Error(message);
       }
 
-      importMatchers(json, matchers, {
+      importMatchersJSON(json, matchers, {
         onSuccess: () => {
           setImportLink("");
           setIsImportingLink(false);

--- a/packages/popup/src/lib/import.ts
+++ b/packages/popup/src/lib/import.ts
@@ -16,9 +16,9 @@ export function importMatchersCSV(
     .map((row) => row.trim())
     .filter(Boolean);
 
-  const queriesToAdd = [];
-
   if (!rows || !rows.length) return;
+
+  const queriesToAdd = [];
 
   for (const row of rows) {
     const parsed = parseDelimitedString(row);

--- a/packages/popup/src/lib/import.ts
+++ b/packages/popup/src/lib/import.ts
@@ -23,7 +23,9 @@ export function importMatchersCSV(
   for (const row of rows) {
     const parsed = parseDelimitedString(row);
 
-    queriesToAdd.push(parsed);
+    if (parsed.length > 0) {
+      queriesToAdd.push(parsed);
+    }
   }
 
   const newMatchers: Matcher[] = queriesToAdd.map((queries) => ({

--- a/packages/popup/src/lib/import.ts
+++ b/packages/popup/src/lib/import.ts
@@ -1,11 +1,48 @@
 import { v4 as uuidv4 } from "uuid";
 
-import { getSchemaByVersion } from "@worm/shared";
+import { getSchemaByVersion, parseDelimitedString } from "@worm/shared";
 import { storageSetByKeys } from "@worm/shared/src/storage";
 import { Matcher } from "@worm/types/src/rules";
 import { StorageSetOptions } from "@worm/types/src/storage";
 
-export default async function importMatchers(
+export function importMatchersCSV(
+  fromUserInput: string | ArrayBuffer | null,
+  currentMatchers: Matcher[] | undefined,
+  options: StorageSetOptions
+) {
+  const csvData = fromUserInput?.toString();
+  const rows = csvData
+    ?.split("\n")
+    .map((row) => row.trim())
+    .filter(Boolean);
+
+  const queriesToAdd = [];
+
+  if (!rows || !rows.length) return;
+
+  for (const row of rows) {
+    const parsed = parseDelimitedString(row);
+
+    queriesToAdd.push(parsed);
+  }
+
+  const newMatchers: Matcher[] = queriesToAdd.map((queries) => ({
+    active: true,
+    identifier: uuidv4(),
+    queries,
+    queryPatterns: [],
+    replacement: "",
+  }));
+
+  return storageSetByKeys(
+    {
+      matchers: [...(currentMatchers ?? []), ...newMatchers],
+    },
+    options
+  );
+}
+
+export async function importMatchersJSON(
   fromUserInput: any,
   currentMatchers: Matcher[] | undefined,
   options: StorageSetOptions

--- a/packages/popup/src/lib/language/english.ts
+++ b/packages/popup/src/lib/language/english.ts
@@ -96,6 +96,8 @@ export default {
     EMPTY_RULES_LIST_ALERT_TITLE: "No active rules",
     EMPTY_RULES_LIST_ALERT_BODY: "Add a rule to start replacing text again.",
     REFRESH_REQUIRED: "You must refresh the page to see these changes.",
+    RULES_CLIPBOARD_PASTE_ERROR:
+      "Error pasting rules. Please check your browser's security settings.",
   },
   support: {
     CONTACT_SUPPORT_FORM_EMPTY_MESSAGE_ERROR: "Message is required",

--- a/packages/popup/src/lib/routes.ts
+++ b/packages/popup/src/lib/routes.ts
@@ -3,7 +3,7 @@ import { isFirefox } from "@worm/shared/src/browser";
 export const CAN_UPLOAD_PARAMETER = "u";
 export const NOTIFY_PARAMETER = "msg";
 
-export function canUploadDirect() {
+export function getCanUploadDirect() {
   if (!isFirefox()) return true;
 
   try {

--- a/packages/shared/src/strings.ts
+++ b/packages/shared/src/strings.ts
@@ -1,3 +1,37 @@
+export const QUERY_PASTE_DELIMITER = "\n";
+
 export function capitalize(string = "") {
   return `${string.charAt(0).toUpperCase()}${string.substring(1)}`;
+}
+
+export function getFileExtension(file: File) {
+  return file.name.split(".").pop()?.toLowerCase();
+}
+
+export function parseDelimitedString(input: string) {
+  const items: string[] = [];
+  let currentItem = "";
+  let insideQuotes = false;
+
+  for (let i = 0; i < input.length; i++) {
+    const char = input[i];
+
+    if (char === '"') {
+      insideQuotes = !insideQuotes;
+    } else if (char === "," && !insideQuotes) {
+      // end of an item - add it to our list and reset
+      items.push(currentItem.trim());
+      currentItem = "";
+    } else {
+      currentItem += char;
+    }
+  }
+
+  // don't forget the last item
+  if (currentItem) {
+    items.push(currentItem.trim());
+  }
+
+  // clean up quotes from the items
+  return items.map((item) => item.replace(/^"(.*)"$/, "$1"));
 }

--- a/packages/shared/src/strings.ts
+++ b/packages/shared/src/strings.ts
@@ -33,5 +33,10 @@ export function parseDelimitedString(input: string) {
   }
 
   // clean up quotes from the items
-  return items.map((item) => item.replace(/^"(.*)"$/, "$1"));
+  const unquoted = items.map((item) => item.replace(/^"(.*)"$/, "$1"));
+
+  // clean up empty queries
+  const filtered = unquoted.filter(Boolean);
+
+  return filtered;
 }

--- a/packages/testing/src/mock-webextension-polyfill.ts
+++ b/packages/testing/src/mock-webextension-polyfill.ts
@@ -430,7 +430,7 @@ class MockStorage<T> implements TStorage {
             }
           });
 
-          this._store[area] = newStore;
+          this._store[area] = deepClone(newStore);
 
           if (Object.keys(changes).length > 0) {
             Array.from(this._listeners).forEach((listener) => {


### PR DESCRIPTION
## Major

- Adds support for importing rules from CSV file - This currently only supports adding queries in bulk. Each CSV row is treated as a new rule and each column a query on that rule.
- Adds support for bulk-adding queries by pasting a list of queries separated by newlines