### PR TITLE
refactor(popup): domain list zero-state copy

### DIFF
--- a/packages/popup/src/components/domain-input/DomainInput.tsx
+++ b/packages/popup/src/components/domain-input/DomainInput.tsx
@@ -97,7 +97,7 @@ export default function DomainInput() {
                 <Alert
                   title={lang.EMPTY_DOMAINS_LIST_ALERT_TITLE}
                   style={{ maxWidth: ALERT_SIZES.sm, transition: "all 90ms" }}
-                  severity={isDenying ? "success" : "warning"}
+                  severity={isDenying ? "info" : "warning"}
                 >
                   {isDenying
                     ? lang.EMPTY_DOMAINS_LIST_ALERT_BODY_DENY

--- a/packages/popup/src/components/domain-input/DomainInput.tsx
+++ b/packages/popup/src/components/domain-input/DomainInput.tsx
@@ -97,7 +97,7 @@ export default function DomainInput() {
                 <Alert
                   title={lang.EMPTY_DOMAINS_LIST_ALERT_TITLE}
                   style={{ maxWidth: ALERT_SIZES.sm, transition: "all 90ms" }}
-                  severity={isDenying ? "info" : "warning"}
+                  severity={isDenying ? "success" : "warning"}
                 >
                   {isDenying
                     ? lang.EMPTY_DOMAINS_LIST_ALERT_BODY_DENY

--- a/packages/popup/src/lib/language/english.ts
+++ b/packages/popup/src/lib/language/english.ts
@@ -59,9 +59,9 @@ export default {
     DOMAINS_LIST_HEADING: "Domain List",
     EMPTY_DOMAINS_LIST_ALERT_TITLE: "No domains",
     EMPTY_DOMAINS_LIST_ALERT_BODY_ALLOW:
-      "None of your replacements are being applied. To starting replacing on specific sites, add them to your domains list. Alternatively, change your list type to 'Blocklist' to use your rules more broadly.",
+      "None of your replacements are being applied. To start replacing on specific sites, add them to your domains list. Alternatively, change your list type to 'Blocklist' to use your rules more broadly.",
     EMPTY_DOMAINS_LIST_ALERT_BODY_DENY:
-      "Text replacements are active on all websites. To limit replacements to specific sites, add them to your domains list.",
+      "Text replacements are active on all websites. To avoid replacing on specific sites, add them to your domains list.",
     LIST_EFFECT_ALLOWLIST_DESCRIPTION:
       "Word replacements will only work on the domains you list",
     LIST_EFFECT_ALLOWLIST_LABEL: "Only on listed domains",


### PR DESCRIPTION
## Minor

- Updates the Popup's domain list zero-state copy to be more clear
- Fixes a typo in the same alert