### PR TITLE
fix(popup): disabled banner height

### DIFF
--- a/packages/popup/src/components/alert/DisabledBanner.tsx
+++ b/packages/popup/src/components/alert/DisabledBanner.tsx
@@ -48,24 +48,25 @@ export default function DisabledBanner() {
   };
 
   return (
-    <Slide
-      disableEnter
-      isOpen={isDisabledMessage}
+    <div
+      style={{ height: isDisabledMessage ? 32 : "auto" }}
       data-testid="disabled-banner"
     >
-      <div
-        className="alert alert-danger d-flex align-items-center justify-content-center gap-1 rounded-0 mb-0 py-1 fs-sm"
-        role="alert"
-      >
-        {language.layout.DISABLED_BANNER_BODY}
-        <Button
-          className="btn btn-link text-decoration-none fs-sm p-0"
-          onClick={handleEnableClick}
-          data-testid="enable-button"
+      <Slide disableEnter isOpen={isDisabledMessage}>
+        <div
+          className="alert alert-danger d-flex align-items-center justify-content-center gap-1 rounded-0 mb-0 py-1 fs-sm"
+          role="alert"
         >
-          {language.layout.DISABLED_BANNER_ENABLE_BUTTON_TEXT}
-        </Button>
-      </div>
-    </Slide>
+          {language.layout.DISABLED_BANNER_BODY}
+          <Button
+            className="btn btn-link text-decoration-none fs-sm p-0"
+            onClick={handleEnableClick}
+            data-testid="enable-button"
+          >
+            {language.layout.DISABLED_BANNER_ENABLE_BUTTON_TEXT}
+          </Button>
+        </div>
+      </Slide>
+    </div>
   );
 }

--- a/packages/popup/src/containers/Layout.tsx
+++ b/packages/popup/src/containers/Layout.tsx
@@ -162,7 +162,7 @@ export default function Layout({ children }: LayoutProps) {
                   color: preferences?.extensionEnabled
                     ? "var(--bs-green)"
                     : "rgba(var(--bs-tertiary-color-rgb), 0.15)",
-                  padding: "5px 4px 3px",
+                  padding: "3px 4px",
                   transition: "all 150ms",
                 },
               }}


### PR DESCRIPTION
## Minor

- Resolves an issue with the Popup's disabled banner shrinking when the main content became scrollable
- Moves the Popup's toggle button icon up a little to align better