### PR TITLE
chore(popup): revert latest domain list ui changes

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
     "name": "Dan Lovelace",
     "url": "https://github.com/dan-lovelace/word-replacer-max"
   },
-  "version": "0.9.6",
+  "version": "0.10.0",
   "license": "GPL-3.0-or-later",
   "description": "A browser extension for replacing text on web pages",
   "type": "module",

--- a/packages/background/src/lib/storage.ts
+++ b/packages/background/src/lib/storage.ts
@@ -1,6 +1,8 @@
 import { v4 as uuidv4 } from "uuid";
 
-import { DEFAULT_USE_GLOBAL_REPLACEMENT_STYLE } from "@worm/shared/src/replace/lib/style";
+import {
+  DEFAULT_USE_GLOBAL_REPLACEMENT_STYLE,
+} from "@worm/shared/src/replace/lib/style";
 import {
   BASELINE_STORAGE_VERSION,
   runStorageMigrations,
@@ -30,7 +32,7 @@ export async function initializeStorage() {
   const initialStorage: SyncStorage = {};
 
   if (domainList === undefined) {
-    initialStorage.domainList = [];
+    initialStorage.domainList = ["docs.google.com", "github.com"];
   }
 
   if (exportLinks === undefined) {

--- a/packages/popup/src/components/alert/DisabledBanner.tsx
+++ b/packages/popup/src/components/alert/DisabledBanner.tsx
@@ -1,3 +1,4 @@
+import { VNode } from "preact";
 import { useEffect, useState } from "preact/hooks";
 
 import { storageGetByKeys, storageSetByKeys } from "@worm/shared/src/storage";
@@ -9,11 +10,11 @@ import Button from "../button/Button";
 import Slide from "../transition/Slide";
 
 export default function DisabledBanner() {
-  const [isDisabledMessage, setIsDisabledMessage] = useState<boolean>();
+  const [disabledContent, setDisabledContent] = useState<VNode | null>(null);
 
   const {
     storage: {
-      sync: { preferences },
+      sync: { domainList, preferences },
     },
   } = useConfig();
   const language = useLanguage();
@@ -24,19 +25,45 @@ export default function DisabledBanner() {
         "preferences",
       ]);
 
-      setIsDisabledMessage(
-        Boolean(currentPreferences?.extensionEnabled) === false
-      );
+      if (currentPreferences?.extensionEnabled === false) {
+        setDisabledContent(
+          <>
+            {language.layout.DISABLED_BANNER_BODY}
+            <Button
+              className="btn btn-link text-decoration-none fs-sm p-0"
+              onClick={handleEnableClick}
+              data-testid="enable-button"
+            >
+              {language.layout.DISABLED_BANNER_ENABLE_BUTTON_TEXT}
+            </Button>
+          </>
+        );
+      } else {
+        updateDomainListDisablement();
+      }
     }
 
     initialize();
   }, []);
 
   useEffect(() => {
-    if (isDisabledMessage && preferences?.extensionEnabled === true) {
-      setIsDisabledMessage(false);
+    updateDomainListDisablement();
+  }, [domainList, preferences?.domainListEffect]);
+
+  useEffect(() => {
+    if (disabledContent && preferences?.extensionEnabled === true) {
+      setDisabledContent(null);
     }
   }, [preferences?.extensionEnabled]);
+
+  const handleDomainListEffectClick = () => {
+    const newPreferences = Object.assign({}, preferences);
+    newPreferences.domainListEffect = "deny";
+
+    storageSetByKeys({
+      preferences: newPreferences,
+    });
+  };
 
   const handleEnableClick = () => {
     const newPreferences = Object.assign({}, preferences);
@@ -47,24 +74,36 @@ export default function DisabledBanner() {
     });
   };
 
+  const updateDomainListDisablement = () => {
+    if (!domainList?.length && preferences?.domainListEffect === "allow") {
+      setDisabledContent(
+        <>
+          {language.layout.EMPTY_DOMAIN_ALLOWLIST_BODY}
+          <Button
+            className="btn btn-link text-decoration-none fs-sm p-0"
+            onClick={handleDomainListEffectClick}
+          >
+            {language.layout.EMPTY_DOMAIN_ALLOWLIST_SWITCH_BUTTON_TEXT}
+          </Button>
+          {language.layout.EMPTY_DOMAIN_ALLOWLIST_OR_TEXT}
+        </>
+      );
+    } else {
+      setDisabledContent(null);
+    }
+  };
+
   return (
     <div
-      style={{ height: isDisabledMessage ? 32 : "auto" }}
+      style={{ height: disabledContent ? 32 : "auto" }}
       data-testid="disabled-banner"
     >
-      <Slide disableEnter isOpen={isDisabledMessage}>
+      <Slide disableEnter isOpen={!!disabledContent}>
         <div
           className="alert alert-danger d-flex align-items-center justify-content-center gap-1 rounded-0 mb-0 py-1 fs-sm"
           role="alert"
         >
-          {language.layout.DISABLED_BANNER_BODY}
-          <Button
-            className="btn btn-link text-decoration-none fs-sm p-0"
-            onClick={handleEnableClick}
-            data-testid="enable-button"
-          >
-            {language.layout.DISABLED_BANNER_ENABLE_BUTTON_TEXT}
-          </Button>
+          {disabledContent}
         </div>
       </Slide>
     </div>

--- a/packages/popup/src/components/domain-input/DomainInput.tsx
+++ b/packages/popup/src/components/domain-input/DomainInput.tsx
@@ -8,10 +8,7 @@ import { useLanguage } from "../../lib/language";
 import { useConfig } from "../../store/Config";
 
 import { useToast } from "../alert/useToast";
-import Alert, { ALERT_SIZES } from "../Alerts";
 import Chip from "../Chip";
-import MaterialIcon from "../icon/MaterialIcon";
-import Tooltip from "../Tooltip";
 
 export default function DomainInput() {
   const [value, setValue] = useState("");
@@ -23,26 +20,6 @@ export default function DomainInput() {
   } = useConfig();
   const language = useLanguage();
   const { showToast } = useToast();
-
-  const addNewDomain = (hostname?: string) => {
-    if (!hostname || hostname.length === 0) return;
-
-    if (!domainList?.includes(hostname)) {
-      storageSetByKeys(
-        {
-          domainList: [...(domainList || []), hostname],
-        },
-        {
-          onError: (message) => {
-            showToast({
-              message,
-              options: { severity: "danger" },
-            });
-          },
-        }
-      );
-    }
-  };
 
   const handleEffectChange = (effect: DomainEffect) => () => {
     const newPreferences = Object.assign({}, preferences);
@@ -63,7 +40,22 @@ export default function DomainInput() {
 
     if (!value || value.length === 0) return;
 
-    addNewDomain(value);
+    if (!domainList?.includes(value)) {
+      storageSetByKeys(
+        {
+          domainList: [...(domainList || []), value],
+        },
+        {
+          onError: (message) => {
+            showToast({
+              message,
+              options: { severity: "danger" },
+            });
+          },
+        }
+      );
+    }
+
     setValue("");
   };
 
@@ -79,94 +71,16 @@ export default function DomainInput() {
     setValue(event.currentTarget.value);
   };
 
-  const { domains: lang } = language;
-  const domainsExist = Boolean(domainList?.length);
-  const isDenying = preferences?.domainListEffect === "deny";
-
   return (
-    <div className="container-fluid gx-0 d-flex flex-column gap-3">
-      <div className="row">
+    <div className="container-fluid gx-0 d-flex flex-column">
+      <div className="row mb-2">
         <div className="col-12 col-lg-8">
-          <div className="fw-bold fs-5 mb-1">{lang.DOMAINS_LIST_HEADING}</div>
-          <form
-            className="position-relative flex-fill"
-            onSubmit={handleFormSubmit}
-          >
-            <div className="pb-2">
-              {!domainsExist && (
-                <Alert
-                  title={lang.EMPTY_DOMAINS_LIST_ALERT_TITLE}
-                  style={{ maxWidth: ALERT_SIZES.sm, transition: "all 90ms" }}
-                  severity={isDenying ? "success" : "warning"}
-                >
-                  {isDenying
-                    ? lang.EMPTY_DOMAINS_LIST_ALERT_BODY_DENY
-                    : lang.EMPTY_DOMAINS_LIST_ALERT_BODY_ALLOW}
-                </Alert>
-              )}
-              {domainsExist && (
-                <div className="d-flex align-items-start flex-wrap gap-1">
-                  {domainList?.map((domain, idx) => (
-                    <Chip
-                      key={`domain-${idx}`}
-                      identifier={domain}
-                      onRemove={handleRemoveClick}
-                    />
-                  ))}
-                </div>
-              )}
-            </div>
-            <input
-              className="form-control w-100"
-              enterkeyhint="enter"
-              placeholder={lang.ADD_DOMAIN_FORM_INPUT_PLACEHOLDER}
-              type="text"
-              style={{ maxWidth: "400px" }}
-              value={value}
-              onBlur={handleFormSubmit}
-              onInput={handleTextChange}
-            />
-            <button className="visually-hidden" type="submit">
-              {lang.ADD_DOMAIN_FORM_SUBMIT_BUTTON_TEXT}
-            </button>
-          </form>
-        </div>
-      </div>
-      <div className="row">
-        <div className="col-12 col-lg-8">
-          <div className="fw-bold fs-5">{lang.REPLACEMENT_SCOPE_HEADING}</div>
-          <div className="fs-sm mb-2">{lang.REPLACEMENT_SCOPE_SUB_HEADING}</div>
-          <div className="d-flex flex-column gap-2">
-            <div className="form-check d-flex align-items-center m-0">
-              <div>
+          <div className="d-flex align-items-center gap-2">
+            <div>Effect:</div>
+            <div className="d-flex gap-3">
+              <div className="form-check m-0">
                 <input
-                  checked={isDenying}
-                  className="form-check-input"
-                  id="denyRadio"
-                  name="deny"
-                  type="radio"
-                  onChange={handleEffectChange("deny")}
-                />
-                <label className="form-check-label" for="denyRadio">
-                  <span className="fw-medium">
-                    {lang.LIST_EFFECT_BLOCKLIST_NAME}
-                  </span>{" "}
-                  - {lang.LIST_EFFECT_BLOCKLIST_LABEL}
-                </label>
-              </div>
-              &nbsp;
-              <Tooltip title={lang.LIST_EFFECT_BLOCKLIST_DESCRIPTION}>
-                <MaterialIcon
-                  className="text-body-tertiary"
-                  name="info"
-                  size="sm"
-                />
-              </Tooltip>
-            </div>
-            <div className="form-check d-flex align-items-center m-0">
-              <div>
-                <input
-                  checked={!isDenying}
+                  checked={preferences?.domainListEffect === "allow"}
                   className="form-check-input"
                   id="allowRadio"
                   name="allow"
@@ -174,22 +88,57 @@ export default function DomainInput() {
                   onChange={handleEffectChange("allow")}
                 />
                 <label className="form-check-label" for="allowRadio">
-                  <span className="fw-medium">
-                    {lang.LIST_EFFECT_ALLOWLIST_NAME}
-                  </span>{" "}
-                  - {lang.LIST_EFFECT_ALLOWLIST_LABEL}
+                  Allow
                 </label>
               </div>
-              &nbsp;
-              <Tooltip title={lang.LIST_EFFECT_ALLOWLIST_DESCRIPTION}>
-                <MaterialIcon
-                  className="text-body-tertiary"
-                  name="info"
-                  size="sm"
+              <div className="form-check m-0">
+                <input
+                  checked={preferences?.domainListEffect === "deny"}
+                  className="form-check-input"
+                  id="denyRadio"
+                  name="deny"
+                  type="radio"
+                  onChange={handleEffectChange("deny")}
                 />
-              </Tooltip>
+                <label className="form-check-label" for="denyRadio">
+                  Deny
+                </label>
+              </div>
             </div>
           </div>
+        </div>
+      </div>
+      <div className="row">
+        <div className="col-12 col-lg-8">
+          <form
+            className="position-relative flex-fill"
+            onSubmit={handleFormSubmit}
+          >
+            {Boolean(domainList?.length) && (
+              <div className="d-flex align-items-start flex-wrap gap-1 pb-2">
+                {domainList?.map((domain, idx) => (
+                  <Chip
+                    key={idx}
+                    identifier={domain}
+                    onRemove={handleRemoveClick}
+                  />
+                ))}
+              </div>
+            )}
+            <input
+              className="form-control w-100"
+              enterkeyhint="enter"
+              placeholder={language.domains.ADD_DOMAIN_FORM_INPUT_PLACEHOLDER}
+              type="text"
+              style={{ maxWidth: "400px" }}
+              value={value}
+              onBlur={handleFormSubmit}
+              onInput={handleTextChange}
+            />
+            <button className="visually-hidden" type="submit">
+              {language.domains.ADD_DOMAIN_FORM_SUBMIT_BUTTON_TEXT}
+            </button>
+          </form>
         </div>
       </div>
     </div>

--- a/packages/popup/src/lib/language/english.ts
+++ b/packages/popup/src/lib/language/english.ts
@@ -55,24 +55,6 @@ export default {
   domains: {
     ADD_DOMAIN_FORM_INPUT_PLACEHOLDER: "Enter a domain (e.g., example.com)",
     ADD_DOMAIN_FORM_SUBMIT_BUTTON_TEXT: "Add",
-    ADD_CURRENT_DOMAIN_BUTTON_TEXT: "Add current site",
-    DOMAINS_LIST_HEADING: "Domain List",
-    EMPTY_DOMAINS_LIST_ALERT_TITLE: "No domains",
-    EMPTY_DOMAINS_LIST_ALERT_BODY_ALLOW:
-      "None of your replacements are being applied. To start replacing on specific sites, add them to your domains list. Alternatively, change your list type to 'Blocklist' to use your rules more broadly.",
-    EMPTY_DOMAINS_LIST_ALERT_BODY_DENY:
-      "Text replacements are active on all websites. To avoid replacing on specific sites, add them to your domains list.",
-    LIST_EFFECT_ALLOWLIST_DESCRIPTION:
-      "Word replacements will only work on the domains you list",
-    LIST_EFFECT_ALLOWLIST_LABEL: "Only on listed domains",
-    LIST_EFFECT_ALLOWLIST_NAME: "Allowlist",
-    LIST_EFFECT_BLOCKLIST_DESCRIPTION:
-      "Word replacements will work everywhere except the domains you list",
-    LIST_EFFECT_BLOCKLIST_LABEL: "Everywhere except listed domains",
-    LIST_EFFECT_BLOCKLIST_NAME: "Blocklist",
-    REPLACEMENT_SCOPE_HEADING: "List Type",
-    REPLACEMENT_SCOPE_SUB_HEADING:
-      "Choose how you want to control which websites use your replacements.",
   },
   layout: {
     DISABLED_BANNER_BODY: "Extension is disabled.",

--- a/packages/popup/src/lib/language/english.ts
+++ b/packages/popup/src/lib/language/english.ts
@@ -59,6 +59,9 @@ export default {
   layout: {
     DISABLED_BANNER_BODY: "Extension is disabled.",
     DISABLED_BANNER_ENABLE_BUTTON_TEXT: "Enable now",
+    EMPTY_DOMAIN_ALLOWLIST_BODY: "No domains allowed – rules are disabled.",
+    EMPTY_DOMAIN_ALLOWLIST_OR_TEXT: "or add domains.",
+    EMPTY_DOMAIN_ALLOWLIST_SWITCH_BUTTON_TEXT: "Switch to blocklist",
   },
   options: {
     CORRUPTED_IMPORT_CONTENT: "It looks like your export file is corrupted.",


### PR DESCRIPTION
## Major

- Reverts UI updates to the Popup's Domains tab - Back-to-back 1 star reviews showed up in the Chrome store saying replacements aren't working. After performing a TON of manual testing and seeing the automated tests pass, I can only assume users are having trouble with the new UI. I presume the lack of default domains means users are erroneously selecting "Allowlist" without reading the helper text alerting them that no replacements will be applied.

## Minor

- Adds an alert banner when the domain list effect is `allow` and no domains exist

## Assets

|Old UI|New (this PR)|
|-|-|
|![Screenshot 2025-01-19 at 4 52 14 PM](https://github.com/user-attachments/assets/3627eb30-9fe1-43b8-81b6-9ea54a456404)|![Screenshot 2025-01-19 at 4 52 53 PM](https://github.com/user-attachments/assets/6f6420fc-e851-4424-893d-407216985e70)|

|Empty allowlist alert|
|-|
|![Screenshot 2025-01-19 at 5 37 36 PM](https://github.com/user-attachments/assets/acf4c529-54cb-4034-90f5-b0c5bf749203)|

## Notes

- For future reference, it's probably best to keep the UI very simple and without much text
- Additionally, always keep a default domains list to reduce the number of times this becomes possible