### PR TITLE
chore(popup): rule groups polish

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,16 @@ export NODE_ENV=development
    ```
    yarn install
    ```
+   - ⚠️ IMPORTANT: In order to test in Firefox, you need to build AmplifyJS
+     locally and link its `@aws-amplify/core` package to this project (bug
+     report here: https://github.com/aws-amplify/amplify-js/pull/14180):
+     1. Update the fork https://github.com/dan-lovelace/amplify-js and clone it
+     1. Checkout branch `core/fix-convert-firefox-context`
+     1. Run `yarn build`
+     1. Run `yarn link-all`
+     1. Change back into the WRM repository
+     1. Run `yarn link @aws-amplify/core`
+     1. Run `yarn install` (use with the `--force` flag when `unlink`ing)
 1. Run the `build` command using whichever manifest version you desire (`2` or
    `3`)
    ```

--- a/packages/content/src/lib/render.ts
+++ b/packages/content/src/lib/render.ts
@@ -115,12 +115,7 @@ export async function renderContent(msg = "") {
 
   let renderedMatchers = [...matchers];
 
-  if (
-    ruleGroups?.active &&
-    userGroups.value &&
-    groupsHavePermission(userGroups.value, "feat:ruleGroups")
-  ) {
-    // rule groups are active and user is logged in
+  if (ruleGroups?.active) {
     const matcherGroups = getMatcherGroups(syncStorage);
 
     if (matcherGroups !== undefined) {

--- a/packages/popup/cypress/e2e/home-page/rule-groups.cy.ts
+++ b/packages/popup/cypress/e2e/home-page/rule-groups.cy.ts
@@ -25,6 +25,16 @@ const defaultTestMatcherGroups = generateMatcherGroups({
   },
 });
 
+function deleteFirstGroup() {
+  selectors.ruleGroups.manageModal
+    .ruleGroupRows()
+    .first()
+    .within(() => {
+      selectors.ruleGroups.manageModal.deleteGroupButton().click();
+      selectors.ruleGroups.manageModal.deleteGroupButton().click();
+    });
+}
+
 describe("home page rule groups", () => {
   describe("toolbar", () => {
     describe("feature availability", () => {
@@ -102,7 +112,16 @@ describe("home page rule groups", () => {
         selectors.ruleGroups.manageModal
           .ruleGroupRows()
           .should("have.length", 2);
-        cy.findByRole("button", { name: /new group/i }).should("be.visible");
+        cy.findByRole("button", { name: /add group/i }).should("be.visible");
+      });
+
+      it("should show an alert when no groups exist", () => {
+        selectors.ruleGroups.toolbar.modalToggleButton().click();
+        deleteFirstGroup();
+        deleteFirstGroup();
+
+        cy.contains(/create your first group/i).should("be.visible");
+        cy.findByRole("button", { name: /add group/i }).should("be.visible");
       });
 
       it("should allow adding a new group", () => {
@@ -158,14 +177,7 @@ describe("home page rule groups", () => {
 
       it("should delete a group after confirmation", () => {
         selectors.ruleGroups.toolbar.modalToggleButton().click();
-
-        selectors.ruleGroups.manageModal
-          .ruleGroupRows()
-          .first()
-          .within(() => {
-            selectors.ruleGroups.manageModal.deleteGroupButton().click();
-            selectors.ruleGroups.manageModal.deleteGroupButton().click();
-          });
+        deleteFirstGroup();
 
         selectors.ruleGroups.manageModal
           .ruleGroupRows()

--- a/packages/popup/cypress/e2e/home-page/rule-groups.cy.ts
+++ b/packages/popup/cypress/e2e/home-page/rule-groups.cy.ts
@@ -527,7 +527,7 @@ describe("home page rule groups", () => {
           });
       });
 
-      it("should not show the option to add to group when no groups exist", () => {
+      it("should disable the option to add to group when no groups exist", () => {
         selectors.ruleGroups.toolbar.modalToggleButton().click();
         selectors.ruleGroups.manageModal.ruleGroupRows().each((row) => {
           cy.wrap(row).within(() => {
@@ -543,7 +543,7 @@ describe("home page rule groups", () => {
           .within(() => {
             selectors.rules.ruleGroups.addToGroupMenu
               .toggleButton()
-              .should("not.exist");
+              .should("have.attr", "disabled");
           });
       });
 

--- a/packages/popup/cypress/e2e/home-page/rule-groups.cy.ts
+++ b/packages/popup/cypress/e2e/home-page/rule-groups.cy.ts
@@ -38,7 +38,7 @@ describe("home page rule groups", () => {
         selectors.ruleGroups.toolbar.root().should("not.exist");
       });
 
-      it("should not display when logged out and feature is enabled", () => {
+      it("should display when logged out and feature is enabled", () => {
         cy.visitWithStorage({
           sync: {
             ...defaultTestMatcherGroups,
@@ -48,7 +48,7 @@ describe("home page rule groups", () => {
           },
         });
 
-        selectors.ruleGroups.toolbar.root().should("not.exist");
+        selectors.ruleGroups.toolbar.root().should("be.visible");
       });
 
       it("should not display when logged in and feature is disabled", () => {

--- a/packages/popup/cypress/e2e/options-page/rule-groups.cy.ts
+++ b/packages/popup/cypress/e2e/options-page/rule-groups.cy.ts
@@ -12,8 +12,8 @@ describe("options page rule groups", () => {
       });
     });
 
-    it("should not display when logged out", () => {
-      selectors.options.ruleGroups.inputWrapper().should("not.exist");
+    it("should display when logged out", () => {
+      selectors.options.ruleGroups.inputWrapper().should("be.visible");
     });
 
     it("should display when logged in", () => {

--- a/packages/popup/src/components/Tooltip.tsx
+++ b/packages/popup/src/components/Tooltip.tsx
@@ -1,15 +1,20 @@
+import { ComponentProps } from "preact";
 import { useEffect, useRef } from "preact/hooks";
 
 import { Tooltip as BSTooltip } from "bootstrap";
 
-import { PreactChildren } from "../lib/types";
+import { cx } from "@worm/shared";
 
-type TooltipProps = {
-  children: PreactChildren;
+type TooltipProps = ComponentProps<"span"> & {
   title: string;
 };
 
-export default function Tooltip({ children, title }: TooltipProps) {
+export default function Tooltip({
+  children,
+  className,
+  title,
+  ...rest
+}: TooltipProps) {
   const tooltipRef = useRef<HTMLSpanElement>(null);
 
   useEffect(() => {
@@ -24,10 +29,14 @@ export default function Tooltip({ children, title }: TooltipProps) {
 
   return (
     <span
-      className="d-inline-flex align-items-center user-select-none"
+      className={cx(
+        "d-inline-flex align-items-center user-select-none",
+        className
+      )}
       data-bs-toggle="tooltip"
       data-bs-title={title}
       ref={tooltipRef}
+      {...rest}
     >
       {children}
     </span>

--- a/packages/popup/src/components/options/RuleGroups.tsx
+++ b/packages/popup/src/components/options/RuleGroups.tsx
@@ -57,7 +57,9 @@ export default function RuleGroups({}: ReplacementGroupsProps) {
       </div>
       <Indented data-testid="rule-groups-description">
         <div className="fs-sm">
-          Group your rules into categories and easily switch between them.
+          Group your rules into categories and easily switch between them. Hold
+          Ctrl (Windows) or Command (Mac) to select multiple groups and combine
+          their replacements.
         </div>
       </Indented>
     </div>

--- a/packages/popup/src/components/options/RuleGroups.tsx
+++ b/packages/popup/src/components/options/RuleGroups.tsx
@@ -33,10 +33,6 @@ export default function RuleGroups({}: ReplacementGroupsProps) {
 
   const isActive = Boolean(ruleGroups?.active);
 
-  if (!hasAccess("feat:ruleGroups")) {
-    return <></>;
-  }
-
   return (
     <div data-testid="rule-groups">
       <div

--- a/packages/popup/src/components/replacement-input/ReplacementInput.tsx
+++ b/packages/popup/src/components/replacement-input/ReplacementInput.tsx
@@ -276,6 +276,7 @@ export default function ReplacementInput({
                 style: {
                   width: INPUT_BUTTON_WIDTH,
                 },
+                title: "Add to group",
                 "aria-label": "Rule groups dropdown toggle",
                 "data-testid": "rule-groups-dropdown-toggle",
               }}

--- a/packages/popup/src/components/replacement-input/ReplacementInput.tsx
+++ b/packages/popup/src/components/replacement-input/ReplacementInput.tsx
@@ -316,7 +316,13 @@ export default function ReplacementInput({
         </Button>
       </form>
       {canGroupRules && (
-        <div className="d-flex gap-1 py-2" data-testid="included-groups-list">
+        <div
+          className="d-flex flex-wrap gap-1 py-2"
+          data-testid="included-groups-list"
+          style={{
+            width: INPUT_WIDTH_BASE,
+          }}
+        >
           {includedGroups.map((group) => (
             <Tooltip
               key={group.identifier}

--- a/packages/popup/src/components/replacement-input/ReplacementInput.tsx
+++ b/packages/popup/src/components/replacement-input/ReplacementInput.tsx
@@ -317,7 +317,7 @@ export default function ReplacementInput({
       </form>
       {canGroupRules && (
         <div
-          className="d-flex flex-wrap gap-1 py-2"
+          className="d-flex flex-wrap gap-1 pt-1 pb-1"
           data-testid="included-groups-list"
           style={{
             width: INPUT_WIDTH_BASE,

--- a/packages/popup/src/components/replacement-input/ReplacementInput.tsx
+++ b/packages/popup/src/components/replacement-input/ReplacementInput.tsx
@@ -266,59 +266,54 @@ export default function ReplacementInput({
               />
             </div>
           )}
-          {canGroupRules &&
-            allGroups.length > 0 &&
-            (availableGroups.length > 0 ||
-              allGroups.length === includedGroups.length) && (
-              <DropdownButton<IconButtonProps>
-                offset={0}
-                componentProps={{
-                  className: cx(ICON_BUTTON_BASE_CLASS, "px-2"),
-                  icon: "more_vert",
-                  iconProps: {
-                    className: "text-secondary",
-                  },
-                  style: {
-                    width: INPUT_BUTTON_WIDTH,
-                  },
-                  "aria-label": "Rule groups dropdown toggle",
-                  "data-testid": "rule-groups-dropdown-toggle",
-                }}
-                Component={IconButton}
-                menuContent={
-                  <div data-testid="rule-groups-menu">
-                    <MenuItemContainer className="border-bottom">
-                      Add to group
-                    </MenuItemContainer>
-                    <DropdownMenuContainer>
-                      {availableGroups.length ? (
-                        availableGroups.map(
-                          (group) =>
-                            !group.matchers?.includes(identifier) && (
-                              <MenuItem
-                                key={group.identifier}
-                                onClick={handleAddToGroupClick(
-                                  group.identifier
-                                )}
-                                data-testid="add-to-group-button"
-                              >
-                                <RuleGroupColor color={group.color} />
-                                {group.name}
-                              </MenuItem>
-                            )
-                        )
-                      ) : (
-                        <div className="px-1">
-                          <Alert severity="info">
-                            No more groups available
-                          </Alert>
-                        </div>
-                      )}
-                    </DropdownMenuContainer>
-                  </div>
-                }
-              />
-            )}
+          {canGroupRules && (
+            <DropdownButton<IconButtonProps>
+              offset={0}
+              componentProps={{
+                className: cx(ICON_BUTTON_BASE_CLASS, "px-2"),
+                disabled: disabled || allGroups.length === 0,
+                disabledTooltip: "You don't have any rule groups",
+                icon: "more_vert",
+                iconProps: {
+                  className: "text-secondary",
+                },
+                style: {
+                  width: INPUT_BUTTON_WIDTH,
+                },
+                "aria-label": "Rule groups dropdown toggle",
+                "data-testid": "rule-groups-dropdown-toggle",
+              }}
+              Component={IconButton}
+              menuContent={
+                <div data-testid="rule-groups-menu">
+                  <MenuItemContainer className="border-bottom">
+                    Add to group
+                  </MenuItemContainer>
+                  <DropdownMenuContainer>
+                    {availableGroups.length ? (
+                      availableGroups.map(
+                        (group) =>
+                          !group.matchers?.includes(identifier) && (
+                            <MenuItem
+                              key={group.identifier}
+                              onClick={handleAddToGroupClick(group.identifier)}
+                              data-testid="add-to-group-button"
+                            >
+                              <RuleGroupColor color={group.color} />
+                              {group.name}
+                            </MenuItem>
+                          )
+                      )
+                    ) : (
+                      <div className="px-1">
+                        <Alert severity="info">No more groups available</Alert>
+                      </div>
+                    )}
+                  </DropdownMenuContainer>
+                </div>
+              }
+            />
+          )}
         </div>
         <Button className="visually-hidden" disabled={disabled} type="submit">
           Save

--- a/packages/popup/src/components/replacement-input/ReplacementInput.tsx
+++ b/packages/popup/src/components/replacement-input/ReplacementInput.tsx
@@ -181,16 +181,12 @@ export default function ReplacementInput({
     };
   }, [sync]);
 
-  const canGroupRules = useMemo(
-    () => ruleGroups?.active && hasAccess("feat:ruleGroups"),
-    [authIdToken, ruleGroups?.active]
-  );
-
   const canSuggest = useMemo(
     () => replacementSuggest?.active && hasAccess("api:post:Suggest"),
     [authIdToken, replacementSuggest?.active]
   );
 
+  const canGroupRules = Boolean(ruleGroups?.active);
   const inputWidth =
     INPUT_WIDTH_BASE -
     ((canSuggest ? INPUT_BUTTON_WIDTH - 1 : 0) +

--- a/packages/popup/src/components/replacement-input/ReplacementSuggest.tsx
+++ b/packages/popup/src/components/replacement-input/ReplacementSuggest.tsx
@@ -200,7 +200,7 @@ export default function ReplacementSuggest({
         disabled: isGenerateReplacementsDisabled,
         disabledTooltip: "Add search terms to get suggestions",
         icon: magicWand,
-        title: "Get Suggestions",
+        title: "Get suggestions",
         style: {
           opacity: isGenerateReplacementsDisabled ? 0.6 : 1,
           width: INPUT_BUTTON_WIDTH,

--- a/packages/popup/src/components/rule-groups/RuleGroupsModal.tsx
+++ b/packages/popup/src/components/rule-groups/RuleGroupsModal.tsx
@@ -1,5 +1,6 @@
 import { useMemo, useRef } from "preact/hooks";
 
+import { cx } from "@worm/shared";
 import { getMatcherGroups, sortMatcherGroups } from "@worm/shared/src/browser";
 import { storageSetByKeys } from "@worm/shared/src/storage";
 
@@ -7,9 +8,27 @@ import { generateMatcherGroup } from "../../lib/rule-groups";
 import { useConfig } from "../../store/Config";
 
 import { useToast } from "../alert/useToast";
+import Alert from "../Alerts";
 import Button from "../button/Button";
 
 import RuleGroupRow from "./RuleGroupRow";
+
+const AddGroupButton = ({
+  className,
+  handleNewClick,
+}: {
+  className?: string;
+  handleNewClick: () => void;
+}) => (
+  <Button
+    className={cx("btn btn-sm", className ?? "btn-primary")}
+    startIcon="add"
+    onClick={handleNewClick}
+    data-testid="add-group-button"
+  >
+    Add group
+  </Button>
+);
 
 export default function RuleGroupsModal() {
   const hideModalButtonRef = useRef<HTMLButtonElement>(null);
@@ -56,6 +75,8 @@ export default function RuleGroupsModal() {
     [sync]
   );
 
+  const groupsExist = sortedGroups.length > 0;
+
   return (
     <div
       className="modal fade z-modal"
@@ -83,18 +104,26 @@ export default function RuleGroupsModal() {
               className="d-flex flex-column gap-1"
               data-testid="rule-groups-list"
             >
-              {sortedGroups.map((group) => (
-                <RuleGroupRow key={group.identifier} data={group} />
-              ))}
+              {groupsExist ? (
+                sortedGroups.map((group) => (
+                  <RuleGroupRow key={group.identifier} data={group} />
+                ))
+              ) : (
+                <Alert severity="info" title="Create your first group">
+                  Add groups to quickly switch between sets of replacements.
+                  <div className="mt-3">
+                    <AddGroupButton handleNewClick={handleNewClick} />
+                  </div>
+                </Alert>
+              )}
             </div>
             <div className="mt-2" data-testid="rule-groups-actions">
-              <Button
-                startIcon="add"
-                onClick={handleNewClick}
-                data-testid="add-group-button"
-              >
-                New group
-              </Button>
+              {groupsExist && (
+                <AddGroupButton
+                  className="btn-secondary"
+                  handleNewClick={handleNewClick}
+                />
+              )}
             </div>
           </div>
         </div>

--- a/packages/popup/src/components/rule-groups/RuleGroupsToolbar.tsx
+++ b/packages/popup/src/components/rule-groups/RuleGroupsToolbar.tsx
@@ -28,11 +28,19 @@ export default function RuleGroupsToolbar() {
 
   const handleChange =
     (identifier: string) =>
-    (event: JSXInternal.TargetedMouseEvent<HTMLInputElement>) => {
+    (
+      event: JSXInternal.TargetedEvent<
+        HTMLInputElement | HTMLLabelElement,
+        MouseEvent | KeyboardEvent
+      >
+    ) => {
       const storageKey = `${STORAGE_MATCHER_GROUP_PREFIX}${identifier}`;
       const existingGroups = getMatcherGroups(sync) ?? {};
 
-      if (event.ctrlKey || event.metaKey) {
+      const isOptionHeld =
+        "ctrlKey" in event ? event.ctrlKey || event.metaKey : false;
+
+      if (isOptionHeld) {
         const newActive = !Boolean(existingGroups[storageKey]?.active ?? false);
 
         storageSetByKeys(
@@ -71,6 +79,16 @@ export default function RuleGroupsToolbar() {
       }
     };
 
+  const handleKeyDown =
+    (identifier: string) =>
+    (event: JSXInternal.TargetedKeyboardEvent<HTMLLabelElement>) => {
+      if (event.code === "Space") {
+        event.preventDefault();
+
+        handleChange(identifier)(event);
+      }
+    };
+
   if (!ruleGroups?.active) {
     return <></>;
   }
@@ -82,7 +100,7 @@ export default function RuleGroupsToolbar() {
 
   return (
     <div
-      className="bg-white d-flex align-items-center gap-2 position-sticky mx-n1 py-2 top-0 z-3"
+      className="bg-white d-flex align-items-center gap-2 position-sticky mx-n1 pt-2 pb-1 top-0 z-3"
       data-testid="rule-groups-toolbar"
     >
       <IconButton
@@ -116,14 +134,19 @@ export default function RuleGroupsToolbar() {
                   checked={active}
                   className="btn-check"
                   id={inputId}
+                  tabIndex={-1}
                   type="checkbox"
-                  onClick={handleChange(identifier)}
                 />
                 <label
                   className={cx(
                     "btn btn-light btn-sm py-0 d-flex align-items-center gap-2 text-nowrap"
                   )}
-                  for={inputId}
+                  htmlFor={inputId}
+                  role="checkbox"
+                  tabIndex={0}
+                  onClick={handleChange(identifier)}
+                  onKeyDown={handleKeyDown(identifier)}
+                  aria-checked={active}
                   data-testid="rule-group-toggle"
                 >
                   <RuleGroupColor color={color} />

--- a/packages/popup/src/components/rules/RuleList.tsx
+++ b/packages/popup/src/components/rules/RuleList.tsx
@@ -56,7 +56,6 @@ export default function RuleList() {
             >
               <AddNewRule />
             </div>
-            <RuleGroupsModal />
           </>
         ) : (
           <div className="row">
@@ -77,6 +76,7 @@ export default function RuleList() {
             </div>
           </div>
         )}
+        <RuleGroupsModal />
       </div>
     </>
   );

--- a/packages/popup/src/components/rules/RuleList.tsx
+++ b/packages/popup/src/components/rules/RuleList.tsx
@@ -34,7 +34,7 @@ export default function RuleList() {
   return (
     <>
       {canGroupRules && <RuleGroupsToolbar />}
-      <div className={cx(!canGroupRules && "pt-2")}>
+      <div className={cx(canGroupRules ? "pt-1" : "pt-2")}>
         {matchers?.length ? (
           <>
             <div className="row gx-3 gy-2" data-testid="rule-list-wrapper">

--- a/packages/popup/src/components/rules/RuleList.tsx
+++ b/packages/popup/src/components/rules/RuleList.tsx
@@ -16,25 +16,20 @@ import RuleRow from "../rules/RuleRow";
 import AddNewRule from "./AddNewRule";
 
 export default function RuleList() {
-  const { hasAccess } = useAuth();
   const {
     storage: {
-      local: { authIdToken },
       sync,
       sync: { matchers, ruleGroups },
     },
   } = useConfig();
   const { rules: lang } = useLanguage();
 
-  const canGroupRules = useMemo(
-    () => ruleGroups?.active && hasAccess("feat:ruleGroups"),
-    [authIdToken, ruleGroups?.active]
-  );
-
   const renderedMatchers: StorageMatcher[] | undefined = useMemo(
     () => getActiveMatchers(sync),
     [sync]
   );
+
+  const canGroupRules = Boolean(ruleGroups?.active);
 
   return (
     <>

--- a/packages/shared/src/permission/index.ts
+++ b/packages/shared/src/permission/index.ts
@@ -28,7 +28,6 @@ const rolePolicies: UserRolePolicy = {
     "api:post:AuthAcceptTerms",
     "api:post:Suggest",
     "api:get:WhoAmI",
-    "feat:ruleGroups",
   ],
   testMember__2024_11_10: [
     "api:post:AuthAcceptTerms",
@@ -37,14 +36,12 @@ const rolePolicies: UserRolePolicy = {
     "api:post:Suggest",
     "api:get:WhoAmI",
     "api:unlimitedUsage",
-    "feat:ruleGroups",
   ],
   member__2024_11_03: [
     "api:post:AuthAcceptTerms",
     "api:post:AuthDeleteAccount",
     "api:post:Suggest",
     "api:get:WhoAmI",
-    "feat:ruleGroups",
   ],
 };
 

--- a/packages/types/src/permission.ts
+++ b/packages/types/src/permission.ts
@@ -36,8 +36,7 @@ export type UserPermission =
   | "api:post:AuthDeleteAccount"
   | "api:post:AuthTestTokens"
   | "api:post:Suggest"
-  | "api:unlimitedUsage"
-  | "feat:ruleGroups";
+  | "api:unlimitedUsage";
 
 export type UserPoolCustomAttributes = {
   terms_acceptance: TermsAcceptance;


### PR DESCRIPTION
## Major

- Resolves a Firefox-specific JWT decoding issue with Amplify in fork: https://github.com/dan-lovelace/amplify-js - Opened a PR with the Amplify team (https://github.com/aws-amplify/amplify-js/pull/14180) to hopefully get this resolved in the upstream package.

## Minor

- Removes the requirement to be signed in to access rule groups
- Fixes an issue with rule groups multi-select in Firefox