### PR TITLE
feat(shared): merge adjacent text nodes into one

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
     "name": "Dan Lovelace",
     "url": "https://github.com/dan-lovelace/word-replacer-max"
   },
-  "version": "0.11.0",
+  "version": "0.12.0",
   "license": "GPL-3.0-or-later",
   "description": "A browser extension for replacing text on web pages",
   "type": "module",

--- a/packages/popup/cypress/e2e/options-page/rules-import.cy.ts
+++ b/packages/popup/cypress/e2e/options-page/rules-import.cy.ts
@@ -81,14 +81,16 @@ describe("rules import", () => {
       cy.findByRole("button", { name: /import/i }).click();
     });
 
-    s.layout.tabs.rules().click();
-    s.ruleRows().then((ruleRows) => {
-      expect(ruleRows.length).to.eq(12);
+    cy.wait("@share").then(() => {
+      s.layout.tabs.rules().click();
+      s.ruleRows().then((ruleRows) => {
+        expect(ruleRows.length).to.eq(12);
 
-      cy.wrap(ruleRows.slice(2)).each((row, idx) => {
-        cy.wrap(row).within(() => {
-          s.rules.queryInput.chips().then(() => {
-            cy.contains((idx + 1) % 10);
+        cy.wrap(ruleRows.slice(2)).each((row, idx) => {
+          cy.wrap(row).within(() => {
+            s.rules.queryInput.chips().then(() => {
+              cy.contains((idx + 1) % 10);
+            });
           });
         });
       });

--- a/packages/popup/cypress/e2e/options-page/rules-import.cy.ts
+++ b/packages/popup/cypress/e2e/options-page/rules-import.cy.ts
@@ -8,7 +8,7 @@ describe("rules import", () => {
 
   it("should add rules from a csv file", () => {
     cy.fixture("rules-import.csv").as("rulesImport");
-    s.options.rulesImport.label().selectFile("@rulesImport");
+    s.options.rulesImport.fileInputLabel().selectFile("@rulesImport");
 
     s.layout.tabs.rules().click();
     s.ruleRows().then((ruleRows) => {
@@ -42,11 +42,56 @@ describe("rules import", () => {
 
   it("should not add rules from an empty csv file", () => {
     cy.fixture("empty-rules-import.csv").as("emptyRulesImport");
-    s.options.rulesImport.label().selectFile("@emptyRulesImport");
+    s.options.rulesImport.fileInputLabel().selectFile("@emptyRulesImport");
 
     s.layout.tabs.rules().click();
     s.ruleRows().then((ruleRows) => {
       expect(ruleRows.length).to.eq(2);
+    });
+  });
+
+  it("should retain sort order of exports when importing from file", () => {
+    cy.fixture("rules-import.json").as("rulesImport");
+    s.options.rulesImport.fileInputLabel().selectFile("@rulesImport");
+
+    s.layout.tabs.rules().click();
+    s.ruleRows().then((ruleRows) => {
+      expect(ruleRows.length).to.eq(12);
+
+      cy.wrap(ruleRows.slice(2)).each((row, idx) => {
+        cy.wrap(row).within(() => {
+          s.rules.queryInput.chips().then(() => {
+            cy.contains((idx + 1) % 10);
+          });
+        });
+      });
+    });
+  });
+
+  it("should retain sort order of exports when importing from link", () => {
+    cy.intercept("https://cdn.wordreplacermax.com/*.json", {
+      fixture: "rules-import.json",
+    }).as("share");
+
+    s.options.rulesImport.linkImportButton().click();
+    s.options.rulesImport.linkImportForm().within(() => {
+      s.options.rulesImport
+        .linkImportUrlInput()
+        .type("https://cdn.wordreplacermax.com/fake.json");
+      cy.findByRole("button", { name: /import/i }).click();
+    });
+
+    s.layout.tabs.rules().click();
+    s.ruleRows().then((ruleRows) => {
+      expect(ruleRows.length).to.eq(12);
+
+      cy.wrap(ruleRows.slice(2)).each((row, idx) => {
+        cy.wrap(row).within(() => {
+          s.rules.queryInput.chips().then(() => {
+            cy.contains((idx + 1) % 10);
+          });
+        });
+      });
     });
   });
 });

--- a/packages/popup/cypress/fixtures/rules-import.json
+++ b/packages/popup/cypress/fixtures/rules-import.json
@@ -1,0 +1,77 @@
+{
+  "version": 1,
+  "data": {
+    "matchers": [
+      {
+        "active": true,
+        "queries": ["1"],
+        "queryPatterns": [],
+        "replacement": "one",
+        "identifier": "0ca45ad6-ac7b-4c32-a998-f3f7b30a8c3a"
+      },
+      {
+        "active": true,
+        "queries": ["2"],
+        "queryPatterns": [],
+        "replacement": "two",
+        "identifier": "0927e639-178b-467e-b5a1-e035f407e4ff"
+      },
+      {
+        "active": true,
+        "queries": ["3"],
+        "queryPatterns": [],
+        "replacement": "three",
+        "identifier": "77d6e243-4ef6-4c98-a82e-b8b5b0368b9a"
+      },
+      {
+        "active": true,
+        "queries": ["4"],
+        "queryPatterns": [],
+        "replacement": "four",
+        "identifier": "30612a4a-7c37-4f6f-a24b-c42a29136066"
+      },
+      {
+        "active": true,
+        "queries": ["5"],
+        "queryPatterns": [],
+        "replacement": "five",
+        "identifier": "4e45972c-a8bf-43ed-844c-106221cbe8f6"
+      },
+      {
+        "active": true,
+        "queries": ["6"],
+        "queryPatterns": [],
+        "replacement": "six",
+        "identifier": "e745adf6-ce00-4d05-8e36-cb34b1ad74d9"
+      },
+      {
+        "active": true,
+        "queries": ["7"],
+        "queryPatterns": [],
+        "replacement": "seven",
+        "identifier": "04560b66-efc9-4d6f-a715-a4b964ee6a5e"
+      },
+      {
+        "active": true,
+        "queries": ["8"],
+        "queryPatterns": [],
+        "replacement": "eight",
+        "identifier": "60ab5db2-ff87-4460-9bd5-9c2d7935c74e"
+      },
+      {
+        "active": true,
+        "queries": ["9"],
+        "queryPatterns": [],
+        "replacement": "nine",
+        "identifier": "6155e657-edad-4e08-b234-e0dc71cf9a46"
+      },
+      {
+        "active": true,
+        "queries": ["0"],
+        "queryPatterns": [],
+        "replacement": "zero",
+        "identifier": "2fe22f4f-6dfe-4da0-a818-5119d34365a7"
+      }
+    ]
+  }
+}

--- a/packages/popup/cypress/support/selectors.ts
+++ b/packages/popup/cypress/support/selectors.ts
@@ -100,8 +100,11 @@ export const selectors = {
       toggleButton: () => cy.findByTestId("rule-groups-toggle-button"),
     },
     rulesImport: {
-      input: () => cy.findByTestId("file-input__input"),
-      label: () => cy.findByTestId("file-input__label"),
+      fileInput: () => cy.findByTestId("file-input__input"),
+      fileInputLabel: () => cy.findByTestId("file-input__label"),
+      linkImportButton: () => cy.findByTestId("link-import-button"),
+      linkImportForm: () => cy.findByTestId("link-import-form"),
+      linkImportUrlInput: () => cy.findByTestId("link-import-url-input"),
       uploadRedirect: () => cy.findByTestId("file-input__upload-redirect"),
     },
   },
@@ -147,6 +150,7 @@ export const selectors = {
   ruleRows: () => cy.findAllByTestId("rule-row"),
   ruleRowsFirst: () => selectors.ruleRows().first(),
   rules: {
+    deleteButton: () => cy.findByTestId("rule-row__delete-button"),
     list: {
       emptyRulesListAlert: () => cy.findByTestId("empty-rules-list-alert"),
       replacementInput: () => cy.findByTestId("replacement-text-input"),

--- a/packages/popup/src/components/import/Import.tsx
+++ b/packages/popup/src/components/import/Import.tsx
@@ -1,9 +1,9 @@
 import { useState } from "preact/hooks";
 
+import Button from "../button/Button";
+
 import FileImport from "./FileImport";
 import LinkImport from "./LinkImport";
-
-import Button from "../button/Button";
 
 export default function Import() {
   const [isImportingLink, setIsImportingLink] = useState(false);
@@ -16,7 +16,11 @@ export default function Import() {
     <LinkImport setIsImportingLink={setIsImportingLink} />
   ) : (
     <div className="d-flex gap-2">
-      <Button startIcon="link" onClick={handleImportClick}>
+      <Button
+        startIcon="link"
+        onClick={handleImportClick}
+        data-testid="link-import-button"
+      >
         Import from link
       </Button>
       <FileImport />

--- a/packages/popup/src/components/import/LinkImport.tsx
+++ b/packages/popup/src/components/import/LinkImport.tsx
@@ -83,7 +83,11 @@ export default function LinkImport({ setIsImportingLink }: LinkImportProps) {
   };
 
   return (
-    <form className="input-group" onSubmit={handleImportSubmit}>
+    <form
+      className="input-group"
+      onSubmit={handleImportSubmit}
+      data-testid="link-import-form"
+    >
       <input
         autoFocus
         className="form-control"
@@ -93,6 +97,7 @@ export default function LinkImport({ setIsImportingLink }: LinkImportProps) {
         type="url"
         value={importLink}
         onInput={handleImportLinkChange}
+        data-testid="link-import-url-input"
       />
       <Button
         className="btn btn-outline-primary"

--- a/packages/popup/src/components/rules/RuleRow.tsx
+++ b/packages/popup/src/components/rules/RuleRow.tsx
@@ -243,7 +243,6 @@ export default function RuleRow({
       {!disabled && (
         <div className="rule-row-actions col-auto ps-0">
           <IconButton
-            data-dismiss="delete"
             className={cx(
               "px-2",
               isConfirmingDelete
@@ -257,6 +256,8 @@ export default function RuleRow({
             title={isConfirmingDelete ? "Confirm delete rule" : "Delete rule"}
             onBlur={() => clickawayListener(new MouseEvent(""))}
             onClick={handleDeleteClick}
+            data-dismiss="delete"
+            data-testid="rule-row__delete-button"
           />
         </div>
       )}

--- a/packages/popup/src/lib/storage.ts
+++ b/packages/popup/src/lib/storage.ts
@@ -1,4 +1,4 @@
-import { STORAGE_MATCHER_PREFIX } from "@worm/shared/src/browser";
+import { sortMatchers, STORAGE_MATCHER_PREFIX } from "@worm/shared/src/browser";
 import { Matcher } from "@worm/types/src/rules";
 import {
   Storage,
@@ -86,7 +86,7 @@ export const getUpdatedStorage = (
           newMatchers[existingIdx] = newValue;
         }
 
-        (updatedArea as SyncStorage).matchers = newMatchers;
+        (updatedArea as SyncStorage).matchers = sortMatchers(newMatchers);
       } else {
         commonUpdate(storedKey, change);
       }

--- a/packages/shared/cypress/e2e/find-text.cy.ts
+++ b/packages/shared/cypress/e2e/find-text.cy.ts
@@ -83,7 +83,7 @@ describe("findText", () => {
       });
     });
 
-    it("merges two adjacent text nodes into one", () => {
+    it("merges adjacent text nodes into one", () => {
       cy.visitMock({
         targetContents: `
           <p></p>

--- a/packages/shared/cypress/e2e/find-text.cy.ts
+++ b/packages/shared/cypress/e2e/find-text.cy.ts
@@ -82,6 +82,54 @@ describe("findText", () => {
         cy.wrap(result).should("have.length", 1);
       });
     });
+
+    it("merges two adjacent text nodes into one", () => {
+      cy.visitMock({
+        targetContents: `
+          <p></p>
+        `,
+      });
+
+      cy.document().then((document) => {
+        const textNode1 = document.createTextNode("Lorem");
+        const textNode2 = document.createTextNode("ipsum");
+        const target = document.querySelector("p");
+
+        target?.appendChild(textNode1);
+        target?.appendChild(textNode2);
+
+        s.html().then(($element) => {
+          const html = $element.get(0);
+
+          const result = findText(html, "Lorem ipsum", []);
+          cy.wrap(result).should("have.length", 1);
+        });
+      });
+    });
+
+    it("trims empty space around adjacent text nodes before merging", () => {
+      cy.visitMock({
+        targetContents: `
+          <p></p>
+        `,
+      });
+
+      cy.document().then((document) => {
+        const textNode1 = document.createTextNode("Lorem ");
+        const textNode2 = document.createTextNode("  ipsum");
+        const target = document.querySelector("p");
+
+        target?.appendChild(textNode1);
+        target?.appendChild(textNode2);
+
+        s.html().then(($element) => {
+          const html = $element.get(0);
+
+          const result = findText(html, "Lorem ipsum", []);
+          cy.wrap(result).should("have.length", 1);
+        });
+      });
+    });
   });
 
   describe("'case' query pattern only", () => {

--- a/packages/shared/src/replace/find-text.ts
+++ b/packages/shared/src/replace/find-text.ts
@@ -62,7 +62,13 @@ function getAdjacentTextNodes(node: Node): Text[] {
 
 /**
  * Recursively crawls an element in search of a given query and returns a list
- * of matching Text nodes. Also mutates chains of adjacent text nodes
+ * of matching Text nodes.
+ *
+ * @remarks
+ * Also mutates chains of adjacent text nodes by merging them into a single
+ * node and deleting all but the first. This is done in preparation of
+ * replacment to support replacing text across text nodes that are beside each
+ * other. See: https://github.com/dan-lovelace/word-replacer-max/issues/60.
  */
 export function findText(
   element: HTMLElement,

--- a/packages/shared/src/replace/find-text.ts
+++ b/packages/shared/src/replace/find-text.ts
@@ -4,9 +4,65 @@ import { CONTENTS_PROPERTY } from "./lib";
 import { nodeNameBlocklist } from "./lib/dom";
 import { getRegexFlags, patternRegex } from "./lib/regex";
 
+function checkContainsText(
+  content: string,
+  queryPatterns: QueryPattern[],
+  query: string
+) {
+  if (!queryPatterns || queryPatterns.length < 1) {
+    return patternRegex.default(query).test(content);
+  }
+
+  let containsText = false;
+
+  /**
+   * This iterates through all given patterns exhaustively because of pattern
+   * precedence. For example, `wholeWord` failing to match will override a
+   * previous `case` match and return false. It is not acceptable to `some()`
+   * the patterns list.
+   */
+  for (const pattern of queryPatterns) {
+    switch (pattern) {
+      case "case":
+      case "default": {
+        containsText = patternRegex[pattern](query).test(content);
+        break;
+      }
+
+      case "regex":
+      case "wholeWord": {
+        containsText = patternRegex[pattern](
+          query,
+          getRegexFlags(queryPatterns)
+        ).test(content);
+        break;
+      }
+    }
+  }
+
+  return containsText;
+}
+
+function getAdjacentTextNodes(node: Node): Text[] {
+  const nodes: Text[] = [];
+  let currentNode: Node | null = node;
+
+  while (currentNode) {
+    if (currentNode.nodeType === Node.TEXT_NODE) {
+      nodes.push(currentNode as Text);
+    } else {
+      break;
+    }
+
+    currentNode = currentNode.nextSibling;
+  }
+
+  return nodes;
+}
+
 /**
  * Recursively crawls an element in search of a given query and returns a list
- * of matching Text nodes.
+ * of matching Text nodes. Also mutates chains of adjacent text nodes
  */
 export function findText(
   element: HTMLElement,
@@ -14,51 +70,42 @@ export function findText(
   queryPatterns: QueryPattern[],
   found: Text[] = []
 ) {
-  const elementContents = String(element[CONTENTS_PROPERTY]);
-  let containsText = false;
+  if (element.nodeType === Node.TEXT_NODE) {
+    const subsequentTextNodes = getAdjacentTextNodes(element);
 
-  if (!queryPatterns || queryPatterns.length < 1) {
-    // default query pattern
-    containsText = patternRegex.default(query).test(elementContents);
-  } else {
-    for (const pattern of queryPatterns) {
-      switch (pattern) {
-        case "case":
-        case "default": {
-          containsText = patternRegex[pattern](query).test(elementContents);
-          break;
-        }
+    const combinedContent = subsequentTextNodes
+      .map((node) => {
+        const nodeContent = String(node[CONTENTS_PROPERTY]);
 
-        case "regex":
-        case "wholeWord": {
-          containsText = patternRegex[pattern](
-            query,
-            getRegexFlags(queryPatterns)
-          ).test(elementContents);
-          break;
-        }
+        return subsequentTextNodes.length > 1
+          ? nodeContent.trim()
+          : nodeContent;
+      })
+      .join(" ");
+
+    if (
+      checkContainsText(combinedContent, queryPatterns, query) &&
+      !element.parentElement?.dataset["isReplaced"] &&
+      !nodeNameBlocklist.has(String(element.parentNode?.nodeName.toLowerCase()))
+    ) {
+      // Update the element's text content
+      element.textContent = combinedContent;
+
+      // Remove any following text nodes since they have been merged
+      if (subsequentTextNodes.length > 1) {
+        subsequentTextNodes.slice(1).forEach((node) => {
+          node.remove();
+        });
       }
+
+      found.push(element as unknown as Text);
     }
-  }
-
-  if (!containsText) {
-    return found;
-  }
-
-  if (element.hasChildNodes()) {
+  } else if (element.hasChildNodes()) {
     const childElements = Array.from(element.childNodes) as HTMLElement[];
 
     for (const child of childElements) {
       findText(child, query, queryPatterns, found);
     }
-  }
-
-  if (
-    element.nodeType === Node.TEXT_NODE &&
-    !element.parentElement?.dataset["isReplaced"] &&
-    !nodeNameBlocklist.has(String(element.parentNode?.nodeName.toLowerCase()))
-  ) {
-    found.push(element as unknown as Text);
   }
 
   return found;

--- a/packages/shared/src/replace/lib/style.ts
+++ b/packages/shared/src/replace/lib/style.ts
@@ -38,14 +38,11 @@ export function getStylesheet(replacementStyle?: ReplacementStyle) {
   const newStyleElement = document.createElement("style");
   newStyleElement.id = STYLE_ELEMENT_ID;
 
-  const paddingAmount = replacementStyle?.options?.includes("bold") ? 2 : 1;
   const stylesheet = `
     .wrm-style__backgroundColor {
       background-color: ${
         String(replacementStyle?.backgroundColor) || "unset"
       } !important;
-      padding-left: ${paddingAmount}px !important;
-      padding-right: ${paddingAmount}px !important;
     }
 
     .wrm-style__bold {

--- a/packages/webapp/src/App.tsx
+++ b/packages/webapp/src/App.tsx
@@ -7,18 +7,16 @@ import responsiveFontSizes from "@mui/material/styles/responsiveFontSizes";
 import ThemeProvider from "@mui/material/styles/ThemeProvider";
 
 import Layout from "./containers/Layout";
-import { useAuthProvider } from "./lib/auth/AuthProvider";
 import { ROUTES } from "./lib/routes";
-import { muiTheme } from "./style/mui-theme";
-
 import HomePage from "./pages/HomePage";
 import LoginCallbackPage from "./pages/LoginCallbackPage";
-import LoginSuccessPage from "./pages/LoginSuccessPage";
 import LoginPage from "./pages/LoginPage";
+import LoginSuccessPage from "./pages/LoginSuccessPage";
 import NotFoundPage from "./pages/NotFoundPage";
 import PrivacyPage from "./pages/PrivacyPage";
 import SignUpPage from "./pages/SignUpPage";
 import TermsPage from "./pages/TermsPage";
+import { muiTheme } from "./style/mui-theme";
 
 let theme = createTheme(muiTheme);
 theme = responsiveFontSizes(theme);
@@ -45,8 +43,6 @@ function AppRoutes() {
 }
 
 export function App() {
-  const { appUser } = useAuthProvider();
-
   return (
     <ThemeProvider theme={theme}>
       <CssBaseline />

--- a/packages/webapp/src/components/user-reviews/UserReviews.tsx
+++ b/packages/webapp/src/components/user-reviews/UserReviews.tsx
@@ -86,6 +86,36 @@ const userReviews: UserReview[] = [
     rating: 5,
     text: "Dec 8, 2024",
   },
+  {
+    author: "Chrome user",
+    rating: 5,
+    text: "Dec 18, 2024",
+  },
+  {
+    author: "Chrome user",
+    rating: 5,
+    text: "Dec 20, 2024",
+  },
+  {
+    author: "Chrome user",
+    rating: 5,
+    text: "Jan 2, 2025",
+  },
+  {
+    author: "Chrome user",
+    rating: 5,
+    text: "Jan 19, 2025",
+  },
+  {
+    author: "Firefox user",
+    rating: 5,
+    text: "Jan 22, 2025",
+  },
+  {
+    author: "Chrome user",
+    rating: 5,
+    text: "Jan 25, 2025",
+  },
 ];
 
 export default function UserReviews() {


### PR DESCRIPTION
## Breaking changes

- Updates the text finding utility to mutate chains of text nodes into a single one - Resolves #60 

## Minor

- Fixes a minor sorting issue on the Rules Export modal when opening it immediately after importing rules
- Removes the 1px left/right padding from styled replacements with background color enabled
- Adds latest user reviews to Webapp homepage