### PR TITLE
fix(popup): deleting more than one rule with groups enabled

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
     "name": "Dan Lovelace",
     "url": "https://github.com/dan-lovelace/word-replacer-max"
   },
-  "version": "0.12.0",
+  "version": "0.13.0",
   "license": "GPL-3.0-or-later",
   "description": "A browser extension for replacing text on web pages",
   "type": "module",

--- a/packages/popup/cypress/e2e/home-page/rule-groups.cy.ts
+++ b/packages/popup/cypress/e2e/home-page/rule-groups.cy.ts
@@ -582,6 +582,19 @@ describe("home page rule groups", () => {
           });
         });
       });
+
+      it("should not delete more than one rule with groups enabled", () => {
+        selectors.ruleGroups.toolbar.groupToggles().first().click();
+
+        selectors.ruleRowsFirst().within(() => {
+          selectors.rules.deleteButton().click();
+          selectors.rules.deleteButton().click();
+        });
+
+        selectors.ruleGroups.toolbar.groupToggles().first().click();
+
+        selectors.ruleRows().should("have.length", 1);
+      });
     });
   });
 });

--- a/packages/popup/src/components/export/ExportModal.tsx
+++ b/packages/popup/src/components/export/ExportModal.tsx
@@ -155,7 +155,7 @@ export default function ExportModal() {
                           Include
                         </label>
                       </div>
-                      <RuleRow disabled matcher={matcher} matchers={matchers} />
+                      <RuleRow disabled matcher={matcher} />
                     </div>
                   ))}
                 </>

--- a/packages/popup/src/components/rules/RuleList.tsx
+++ b/packages/popup/src/components/rules/RuleList.tsx
@@ -44,7 +44,7 @@ export default function RuleList() {
                   className="rule-row-wrapper col-12 col-xxl-6 position-relative"
                 >
                   <div className="container-fluid gx-1">
-                    <RuleRow matcher={matcher} matchers={renderedMatchers} />
+                    <RuleRow matcher={matcher} />
                   </div>
                 </div>
               ))}

--- a/packages/popup/src/components/rules/RuleRow.tsx
+++ b/packages/popup/src/components/rules/RuleRow.tsx
@@ -19,7 +19,6 @@ import ReplacementInput from "../replacement-input/ReplacementInput";
 
 type RuleRowProps = {
   matcher: Matcher;
-  matchers: Matcher[];
   disabled?: boolean;
 };
 
@@ -32,14 +31,13 @@ export default function RuleRow({
     replacement,
     useGlobalReplacementStyle,
   },
-  matchers,
   disabled = false,
 }: RuleRowProps) {
   const [isConfirmingDelete, setIsConfirmingDelete] = useState(false);
 
   const {
     storage: {
-      sync: { preferences },
+      sync: { matchers, preferences },
     },
   } = useConfig();
   const language = useLanguage();
@@ -49,6 +47,15 @@ export default function RuleRow({
   const { showToast } = useToast();
 
   confirmingDeleteRef.current = isConfirmingDelete;
+
+  const clickawayListener = useCallback((event: MouseEvent) => {
+    if (
+      confirmingDeleteRef.current === true &&
+      (event.target as HTMLElement)?.getAttribute("data-dismiss") !== "delete"
+    ) {
+      setIsConfirmingDelete(false);
+    }
+  }, []);
 
   useEffect(() => {
     if (!preferences?.focusRule) return;
@@ -85,15 +92,6 @@ export default function RuleRow({
       preferences: newPreferences,
     });
   }, [preferences]);
-
-  const clickawayListener = useCallback((event: MouseEvent) => {
-    if (
-      confirmingDeleteRef.current === true &&
-      (event.target as HTMLElement)?.getAttribute("data-dismiss") !== "delete"
-    ) {
-      setIsConfirmingDelete(false);
-    }
-  }, []);
 
   useEffect(() => {
     if (isConfirmingDelete) {
@@ -172,7 +170,7 @@ export default function RuleRow({
       }
 
       storageSetByKeys({
-        matchers: matchers.filter(
+        matchers: matchers?.filter(
           (matcher) => matcher.identifier !== identifier
         ),
       });


### PR DESCRIPTION
## Major

- Resolves an issue that causes more than one rule to be deleted when deleting a single rule assigned to a group with the group enabled