### PR TITLE
feat(shared): adjacent text node regex replacement

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
     "name": "Dan Lovelace",
     "url": "https://github.com/dan-lovelace/word-replacer-max"
   },
-  "version": "0.13.0",
+  "version": "0.14.0",
   "license": "GPL-3.0-or-later",
   "description": "A browser extension for replacing text on web pages",
   "type": "module",

--- a/packages/content/__test__/render.test.ts
+++ b/packages/content/__test__/render.test.ts
@@ -1,0 +1,395 @@
+import { expect } from "@jest/globals";
+
+import {
+  generateMatchers,
+  TEST_GROUP_ID_1,
+  TEST_GROUP_ID_2,
+} from "@worm/popup/cypress/support/generators/rules";
+import { DEFAULT_REPLACEMENT_STYLE } from "@worm/shared/src/replace/lib/style";
+import { DeepPartial } from "@worm/types";
+import { StorageMatcherGroup } from "@worm/types/src/rules";
+import { SyncStorage } from "@worm/types/src/storage";
+
+import { renderCache, renderContent } from "../src/lib/render";
+
+type MockStorage =
+  | DeepPartial<SyncStorage>
+  | Record<string, StorageMatcherGroup>;
+
+const testMatchers = Object.values(generateMatchers());
+
+const mockReplaceAll = jest.fn();
+const mockIsDomainAllowed = jest.fn();
+const mockGetMatcherGroups = jest.fn();
+const mockStorageGetByKeys = jest.fn();
+const mockGetStylesheet = jest.fn(() => document.createElement("style"));
+
+jest.mock("@worm/shared", () => ({
+  replaceAll: (...args: Parameters<typeof mockReplaceAll>) =>
+    mockReplaceAll(...args),
+  isDomainAllowed: (...args: Parameters<typeof mockIsDomainAllowed>) =>
+    mockIsDomainAllowed(...args),
+}));
+
+jest.mock("@worm/shared/src/browser", () => ({
+  getMatcherGroups: (...args: Parameters<typeof mockGetMatcherGroups>) =>
+    mockGetMatcherGroups(...args),
+}));
+
+jest.mock("@worm/shared/src/storage", () => ({
+  storageGetByKeys: (...args: Parameters<typeof mockStorageGetByKeys>) =>
+    mockStorageGetByKeys(...args),
+}));
+
+jest.mock("@worm/shared/src/replace/lib/style", () => ({
+  getStylesheet: (...args: Parameters<typeof mockGetStylesheet>) =>
+    mockGetStylesheet(...args),
+  STYLE_ELEMENT_ID: "test-style-id",
+}));
+
+describe("renderContent", () => {
+  let dateNowSpy: jest.SpyInstance;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+
+    dateNowSpy = jest
+      .spyOn(Date.prototype, "getTime")
+      .mockImplementation(() => 1000);
+
+    mockIsDomainAllowed.mockImplementation(() => true);
+    document.head.innerHTML = "";
+  });
+
+  afterEach(() => {
+    dateNowSpy.mockRestore();
+
+    renderCache.storage = { expires: 0 };
+    renderCache.styleElement = { expires: 0 };
+  });
+
+  it("should call replaceAll with correct parameters when extension is enabled", async () => {
+    const mockStorage: MockStorage = {
+      preferences: {
+        extensionEnabled: true,
+      },
+      domainList: [],
+      matchers: testMatchers,
+      replacementStyle: DEFAULT_REPLACEMENT_STYLE,
+      ruleGroups: { active: false },
+    };
+
+    mockStorageGetByKeys.mockResolvedValue(mockStorage);
+
+    await renderContent();
+
+    expect(mockStorageGetByKeys).toHaveBeenCalledTimes(1);
+    expect(mockReplaceAll).toHaveBeenCalledTimes(1);
+    expect(mockReplaceAll).toHaveBeenCalledWith(
+      testMatchers,
+      DEFAULT_REPLACEMENT_STYLE
+    );
+  });
+
+  it("should not call replaceAll when extension is disabled", async () => {
+    const mockStorage: MockStorage = {
+      preferences: {
+        extensionEnabled: false,
+      },
+      domainList: [],
+      matchers: testMatchers,
+      replacementStyle: DEFAULT_REPLACEMENT_STYLE,
+      ruleGroups: { active: false },
+    };
+
+    mockStorageGetByKeys.mockResolvedValue(mockStorage);
+
+    await renderContent();
+
+    expect(mockStorageGetByKeys).toHaveBeenCalledTimes(1);
+    expect(mockReplaceAll).not.toHaveBeenCalled();
+  });
+
+  it("should respect storage cache hits", async () => {
+    const mockStorage: MockStorage = {
+      preferences: {
+        extensionEnabled: true,
+      },
+      domainList: [],
+      matchers: testMatchers,
+      replacementStyle: DEFAULT_REPLACEMENT_STYLE,
+      ruleGroups: { active: false },
+    };
+
+    mockStorageGetByKeys.mockResolvedValue(mockStorage);
+
+    await renderContent();
+    dateNowSpy.mockImplementation(() => 1050);
+    await renderContent();
+
+    expect(mockStorageGetByKeys).toHaveBeenCalledTimes(1);
+    expect(mockReplaceAll).toHaveBeenCalledTimes(2);
+  });
+
+  it("should respect storage cache misses", async () => {
+    const mockStorage: MockStorage = {
+      preferences: {
+        extensionEnabled: true,
+      },
+      domainList: [],
+      matchers: testMatchers,
+      replacementStyle: DEFAULT_REPLACEMENT_STYLE,
+      ruleGroups: { active: false },
+    };
+
+    mockStorageGetByKeys.mockResolvedValue(mockStorage);
+
+    await renderContent();
+    dateNowSpy.mockImplementation(() => 1150);
+    await renderContent();
+
+    expect(mockStorageGetByKeys).toHaveBeenCalledTimes(2);
+    expect(mockReplaceAll).toHaveBeenCalledTimes(2);
+  });
+
+  it("should not call replaceAll when no matchers exist", async () => {
+    const mockStorage: MockStorage = {
+      preferences: {
+        extensionEnabled: true,
+      },
+      domainList: [],
+      matchers: [],
+      replacementStyle: DEFAULT_REPLACEMENT_STYLE,
+      ruleGroups: { active: false },
+    };
+
+    mockStorageGetByKeys.mockResolvedValue(mockStorage);
+
+    await renderContent();
+
+    expect(mockReplaceAll).not.toHaveBeenCalled();
+  });
+
+  it("should call replaceAll when the only rule group is enabled", async () => {
+    const mockStorage: MockStorage = {
+      preferences: {
+        extensionEnabled: true,
+      },
+      domainList: [],
+      matchers: testMatchers,
+      replacementStyle: DEFAULT_REPLACEMENT_STYLE,
+      ruleGroups: { active: true },
+    };
+
+    mockStorageGetByKeys.mockResolvedValue(mockStorage);
+    mockGetMatcherGroups.mockImplementation(() => ({
+      [TEST_GROUP_ID_1]: {
+        active: false,
+        color: "blue",
+        identifier: "1234",
+        matchers: [],
+        name: "Test Group 1",
+      },
+    }));
+
+    await renderContent();
+
+    expect(mockStorageGetByKeys).toHaveBeenCalledTimes(1);
+    expect(mockReplaceAll).toHaveBeenCalledTimes(1);
+    expect(mockReplaceAll).toHaveBeenCalledWith(
+      testMatchers,
+      DEFAULT_REPLACEMENT_STYLE
+    );
+  });
+
+  it("should not call replaceAll when the only rule group is enabled without rules", async () => {
+    const mockStorage: MockStorage = {
+      preferences: {
+        extensionEnabled: true,
+      },
+      domainList: [],
+      matchers: testMatchers,
+      replacementStyle: DEFAULT_REPLACEMENT_STYLE,
+      ruleGroups: { active: true },
+      [TEST_GROUP_ID_1]: {
+        active: true,
+        color: "blue",
+        identifier: "1234",
+        matchers: [],
+        name: "Test Group 1",
+      },
+    };
+
+    mockStorageGetByKeys.mockResolvedValue(mockStorage);
+    mockGetMatcherGroups.mockImplementation(() => ({
+      [TEST_GROUP_ID_1]: {
+        active: true,
+        color: "blue",
+        identifier: "1234",
+        matchers: [],
+        name: "Test Group 1",
+      },
+    }));
+
+    await renderContent();
+
+    expect(mockStorageGetByKeys).toHaveBeenCalledTimes(1);
+    expect(mockReplaceAll).not.toHaveBeenCalled();
+  });
+
+  it("should call replaceAll when one of many rule groups is enabled without rules", async () => {
+    const mockStorage: MockStorage = {
+      preferences: {
+        extensionEnabled: true,
+      },
+      domainList: [],
+      matchers: testMatchers,
+      replacementStyle: DEFAULT_REPLACEMENT_STYLE,
+      ruleGroups: { active: true },
+    };
+
+    mockStorageGetByKeys.mockResolvedValue(mockStorage);
+    mockGetMatcherGroups.mockImplementation(() => ({
+      [TEST_GROUP_ID_1]: {
+        active: true,
+        color: "blue",
+        identifier: "1234",
+        matchers: [],
+        name: "Test Group 1",
+      },
+      [TEST_GROUP_ID_2]: {
+        active: true,
+        color: "green",
+        identifier: "5678",
+        matchers: ["1234"],
+        name: "Test Group 2",
+      },
+    }));
+
+    await renderContent();
+
+    expect(mockStorageGetByKeys).toHaveBeenCalledTimes(1);
+    expect(mockReplaceAll).toHaveBeenCalledTimes(1);
+    expect(mockReplaceAll).toHaveBeenCalledWith(
+      [testMatchers[0]],
+      DEFAULT_REPLACEMENT_STYLE
+    );
+  });
+
+  it("should not call replaceAll with rules from disabled groups", async () => {
+    const mockStorage: MockStorage = {
+      preferences: {
+        extensionEnabled: true,
+      },
+      domainList: [],
+      matchers: testMatchers,
+      replacementStyle: DEFAULT_REPLACEMENT_STYLE,
+      ruleGroups: { active: true },
+    };
+
+    mockStorageGetByKeys.mockResolvedValue(mockStorage);
+    mockGetMatcherGroups.mockImplementation(() => ({
+      [TEST_GROUP_ID_1]: {
+        active: true,
+        color: "blue",
+        identifier: "1234",
+        matchers: ["1234"],
+        name: "Test Group 1",
+      },
+      [TEST_GROUP_ID_2]: {
+        active: false,
+        color: "green",
+        identifier: "5678",
+        matchers: ["5678"],
+        name: "Test Group 2",
+      },
+    }));
+
+    await renderContent();
+
+    expect(mockStorageGetByKeys).toHaveBeenCalledTimes(1);
+    expect(mockReplaceAll).toHaveBeenCalledTimes(1);
+    expect(mockReplaceAll).toHaveBeenCalledWith(
+      [testMatchers[0]],
+      DEFAULT_REPLACEMENT_STYLE
+    );
+  });
+
+  it("should call replaceAll with rules from all enabled groups", async () => {
+    const mockStorage: MockStorage = {
+      preferences: {
+        extensionEnabled: true,
+      },
+      domainList: [],
+      matchers: testMatchers,
+      replacementStyle: DEFAULT_REPLACEMENT_STYLE,
+      ruleGroups: { active: true },
+    };
+
+    mockStorageGetByKeys.mockResolvedValue(mockStorage);
+    mockGetMatcherGroups.mockImplementation(() => ({
+      [TEST_GROUP_ID_1]: {
+        active: true,
+        color: "blue",
+        identifier: "1234",
+        matchers: ["1234"],
+        name: "Test Group 1",
+      },
+      [TEST_GROUP_ID_2]: {
+        active: true,
+        color: "green",
+        identifier: "5678",
+        matchers: ["5678"],
+        name: "Test Group 2",
+      },
+    }));
+
+    await renderContent();
+
+    expect(mockStorageGetByKeys).toHaveBeenCalledTimes(1);
+    expect(mockReplaceAll).toHaveBeenCalledTimes(1);
+    expect(mockReplaceAll).toHaveBeenCalledWith(
+      [testMatchers[0], testMatchers[1]],
+      DEFAULT_REPLACEMENT_STYLE
+    );
+  });
+
+  it("should call replaceAll with all rules when all groups are disabled", async () => {
+    const mockStorage: MockStorage = {
+      preferences: {
+        extensionEnabled: true,
+      },
+      domainList: [],
+      matchers: testMatchers,
+      replacementStyle: DEFAULT_REPLACEMENT_STYLE,
+      ruleGroups: { active: true },
+    };
+
+    mockStorageGetByKeys.mockResolvedValue(mockStorage);
+    mockGetMatcherGroups.mockImplementation(() => ({
+      [TEST_GROUP_ID_1]: {
+        active: false,
+        color: "blue",
+        identifier: "1234",
+        matchers: ["1234"],
+        name: "Test Group 1",
+      },
+      [TEST_GROUP_ID_2]: {
+        active: false,
+        color: "green",
+        identifier: "5678",
+        matchers: ["5678"],
+        name: "Test Group 2",
+      },
+    }));
+
+    await renderContent();
+
+    expect(mockStorageGetByKeys).toHaveBeenCalledTimes(1);
+    expect(mockReplaceAll).toHaveBeenCalledTimes(1);
+    expect(mockReplaceAll).toHaveBeenCalledWith(
+      [testMatchers[0], testMatchers[1]],
+      DEFAULT_REPLACEMENT_STYLE
+    );
+  });
+});

--- a/packages/content/src/lib/render.ts
+++ b/packages/content/src/lib/render.ts
@@ -1,18 +1,10 @@
 import { isDomainAllowed, replaceAll } from "@worm/shared";
 import { getMatcherGroups } from "@worm/shared/src/browser";
 import {
-  getTokenGroups,
-  groupsHavePermission,
-} from "@worm/shared/src/permission";
-import {
   getStylesheet,
   STYLE_ELEMENT_ID,
 } from "@worm/shared/src/replace/lib/style";
-import {
-  authStorageProvider,
-  storageGetByKeys,
-} from "@worm/shared/src/storage";
-import { UserGroups } from "@worm/types/src/permission";
+import { storageGetByKeys } from "@worm/shared/src/storage";
 import { SyncStorage } from "@worm/types/src/storage";
 
 type Cacheable<T> = {
@@ -23,21 +15,16 @@ type Cacheable<T> = {
 type RenderCache = {
   storage: Cacheable<SyncStorage>;
   styleElement: Cacheable<Element>;
-  userGroups: Cacheable<UserGroups | undefined>;
 };
 
 const RENDER_STORAGE_CACHE_LENGTH_MS = 100;
 const RENDER_STYLE_CACHE_LENGTH_MS = 1000;
-const RENDER_USER_GROUPS_CACHE_LENGTH_MS = 400;
 
 const renderCache: RenderCache = {
   storage: {
     expires: 0,
   },
   styleElement: {
-    expires: 0,
-  },
-  userGroups: {
     expires: 0,
   },
 };
@@ -80,15 +67,6 @@ export async function renderContent(msg = "") {
     return;
   }
 
-  if (now > renderCache.userGroups.expires) {
-    const idToken = (await authStorageProvider.get("authIdToken"))
-      .authIdToken as string | undefined;
-    const groups = getTokenGroups(idToken);
-
-    renderCache.userGroups.expires = now + RENDER_USER_GROUPS_CACHE_LENGTH_MS;
-    renderCache.userGroups.value = groups;
-  }
-
   const {
     storage: {
       value: syncStorage,
@@ -100,7 +78,6 @@ export async function renderContent(msg = "") {
         ruleGroups,
       },
     },
-    userGroups,
   } = renderCache;
 
   if (preferences) {

--- a/packages/content/src/lib/render.ts
+++ b/packages/content/src/lib/render.ts
@@ -20,7 +20,7 @@ type RenderCache = {
 const RENDER_STORAGE_CACHE_LENGTH_MS = 100;
 const RENDER_STYLE_CACHE_LENGTH_MS = 1000;
 
-const renderCache: RenderCache = {
+export const renderCache: RenderCache = {
   storage: {
     expires: 0,
   },
@@ -96,20 +96,22 @@ export async function renderContent(msg = "") {
     const matcherGroups = getMatcherGroups(syncStorage);
 
     if (matcherGroups !== undefined) {
+      const activeGroups = Object.values(matcherGroups).filter(
+        (group) => group.active
+      );
       const groupedMatchers = new Set(
-        Object.values(matcherGroups)
-          .filter((group) => group.active)
-          .map((group) => [...(group.matchers ?? [])])
-          .flat()
+        activeGroups.map((group) => [...(group.matchers ?? [])]).flat()
       );
 
-      if (groupedMatchers.size > 0) {
+      if (groupedMatchers.size > 0 || activeGroups.length > 0) {
         renderedMatchers = renderedMatchers.filter((matcher) =>
           groupedMatchers.has(matcher.identifier)
         );
       }
     }
   }
+
+  if (renderedMatchers.length < 1) return;
 
   replaceAll(renderedMatchers, replacementStyle);
 }

--- a/packages/content/src/lib/render.ts
+++ b/packages/content/src/lib/render.ts
@@ -103,11 +103,9 @@ export async function renderContent(msg = "") {
           .flat()
       );
 
-      if (groupedMatchers.size > 0) {
-        renderedMatchers = renderedMatchers.filter((matcher) =>
-          groupedMatchers.has(matcher.identifier)
-        );
-      }
+      renderedMatchers = renderedMatchers.filter((matcher) =>
+        groupedMatchers.has(matcher.identifier)
+      );
     }
   }
 

--- a/packages/content/src/lib/render.ts
+++ b/packages/content/src/lib/render.ts
@@ -103,9 +103,11 @@ export async function renderContent(msg = "") {
           .flat()
       );
 
-      renderedMatchers = renderedMatchers.filter((matcher) =>
-        groupedMatchers.has(matcher.identifier)
-      );
+      if (groupedMatchers.size > 0) {
+        renderedMatchers = renderedMatchers.filter((matcher) =>
+          groupedMatchers.has(matcher.identifier)
+        );
+      }
     }
   }
 

--- a/packages/popup/cypress/e2e/home-page/rule-groups.cy.ts
+++ b/packages/popup/cypress/e2e/home-page/rule-groups.cy.ts
@@ -583,6 +583,23 @@ describe("home page rule groups", () => {
         });
       });
 
+      it("should allow updating individual rules with groups enabled", () => {
+        selectors.ruleGroups.toolbar.groupToggles().first().click();
+
+        selectors.ruleRowsFirst().within(() => {
+          selectors.rules.queryInput.input().type("lorem").blur();
+        });
+
+        selectors.ruleGroups.toolbar.groupToggles().first().click();
+
+        selectors.ruleRows().should("have.length", 2);
+
+        selectors.ruleRows().then((rows) => {
+          cy.wrap(rows.eq(0)).contains("lorem");
+          cy.wrap(rows.eq(1)).contains("This.");
+        });
+      });
+
       it("should not delete more than one rule with groups enabled", () => {
         selectors.ruleGroups.toolbar.groupToggles().first().click();
 

--- a/packages/shared/cypress/e2e/replace-all.cy.ts
+++ b/packages/shared/cypress/e2e/replace-all.cy.ts
@@ -407,7 +407,41 @@ describe("replaceAll", () => {
       });
     });
 
-    it("replaces text across adjacent text nodes", () => {
+    it("replaces text across adjacent text nodes for single-word queries", () => {
+      cy.visitMock({
+        bodyContents: `
+          <div data-testid="target"></div>
+        `,
+      });
+
+      cy.document().then((document) => {
+        const textNode1 = document.createTextNode("Lorem");
+        const textNode2 = document.createTextNode("ipsum");
+        const target = document.querySelector("[data-testid='target']");
+
+        target?.appendChild(textNode1);
+        target?.appendChild(textNode2);
+
+        replaceAll(
+          [
+            {
+              active: true,
+              identifier: "ABCD-1234",
+              queries: ["loremipsum"],
+              queryPatterns: [],
+              replacement: "sit",
+              useGlobalReplacementStyle: DEFAULT_USE_GLOBAL_REPLACEMENT_STYLE,
+            },
+          ],
+          undefined,
+          document
+        );
+
+        s.target().should("have.text", "sit");
+      });
+    });
+
+    it("replaces text across adjacent text nodes for queries that contain a space", () => {
       cy.visitMock({
         bodyContents: `
           <div data-testid="target"></div>

--- a/packages/shared/cypress/e2e/replace-all.cy.ts
+++ b/packages/shared/cypress/e2e/replace-all.cy.ts
@@ -476,6 +476,76 @@ describe("replaceAll", () => {
     });
   });
 
+  describe("'case' query pattern only", () => {
+    it("replaces text across adjacent text nodes for single-word queries", () => {
+      cy.visitMock({
+        bodyContents: `
+          <div data-testid="target"></div>
+        `,
+      });
+
+      cy.document().then((document) => {
+        const textNode1 = document.createTextNode("Lorem");
+        const textNode2 = document.createTextNode("ipsum");
+        const target = document.querySelector("[data-testid='target']");
+
+        target?.appendChild(textNode1);
+        target?.appendChild(textNode2);
+
+        replaceAll(
+          [
+            {
+              active: true,
+              identifier: "ABCD-1234",
+              queries: ["Loremipsum"],
+              queryPatterns: ["case"],
+              replacement: "sit",
+              useGlobalReplacementStyle: DEFAULT_USE_GLOBAL_REPLACEMENT_STYLE,
+            },
+          ],
+          undefined,
+          document
+        );
+
+        s.target().should("have.text", "sit");
+      });
+    });
+
+    it("replaces text across adjacent text nodes for multiple-word queries", () => {
+      cy.visitMock({
+        bodyContents: `
+          <div data-testid="target"></div>
+        `,
+      });
+
+      cy.document().then((document) => {
+        const textNode1 = document.createTextNode("Lorem");
+        const textNode2 = document.createTextNode("ipsum");
+        const target = document.querySelector("[data-testid='target']");
+
+        target?.appendChild(textNode1);
+        target?.appendChild(textNode2);
+
+        replaceAll(
+          [
+            {
+              active: true,
+              identifier: "ABCD-1234",
+              queries: ["Lorem ipsum"],
+              queryPatterns: ["case"],
+              replacement: "sit",
+              useGlobalReplacementStyle: DEFAULT_USE_GLOBAL_REPLACEMENT_STYLE,
+            },
+          ],
+          undefined,
+          document
+        );
+
+        s.target().should("have.text", "sit");
+      });
+    });
+  });
+
   describe("'regex' query pattern only", () => {
     it("works for regex negative lookaheads", () => {
       cy.visitMock({
@@ -535,6 +605,74 @@ describe("replaceAll", () => {
         .invoke("html")
         .should("match", /^Lorem <span[^>]*>sit<\/span> dolor$/);
     });
+
+    it("replaces text across adjacent text nodes for single-word queries", () => {
+      cy.visitMock({
+        bodyContents: `
+          <div data-testid="target"></div>
+        `,
+      });
+
+      cy.document().then((document) => {
+        const textNode1 = document.createTextNode("Lorem");
+        const textNode2 = document.createTextNode("ipsum");
+        const target = document.querySelector("[data-testid='target']");
+
+        target?.appendChild(textNode1);
+        target?.appendChild(textNode2);
+
+        replaceAll(
+          [
+            {
+              active: true,
+              identifier: "ABCD-1234",
+              queries: ["(Loremipsum)"],
+              queryPatterns: ["regex"],
+              replacement: "sit",
+              useGlobalReplacementStyle: DEFAULT_USE_GLOBAL_REPLACEMENT_STYLE,
+            },
+          ],
+          undefined,
+          document
+        );
+
+        s.target().should("have.text", "sit");
+      });
+    });
+
+    it("replaces text across adjacent text nodes for multiple-word queries", () => {
+      cy.visitMock({
+        bodyContents: `
+          <div data-testid="target"></div>
+        `,
+      });
+
+      cy.document().then((document) => {
+        const textNode1 = document.createTextNode("Lorem");
+        const textNode2 = document.createTextNode("ipsum");
+        const target = document.querySelector("[data-testid='target']");
+
+        target?.appendChild(textNode1);
+        target?.appendChild(textNode2);
+
+        replaceAll(
+          [
+            {
+              active: true,
+              identifier: "ABCD-1234",
+              queries: ["(Lorem) (ipsum)"],
+              queryPatterns: ["regex"],
+              replacement: "sit",
+              useGlobalReplacementStyle: DEFAULT_USE_GLOBAL_REPLACEMENT_STYLE,
+            },
+          ],
+          undefined,
+          document
+        );
+
+        s.target().should("have.text", "sit");
+      });
+    });
   });
 
   describe("'wholeWord' query pattern only", () => {
@@ -567,7 +705,7 @@ describe("replaceAll", () => {
       });
     });
 
-    it("trims empty space around sibling elements when adjacent text nodes exist", () => {
+    it("replaces text across adjacent text nodes for single-word queries", () => {
       cy.visitMock({
         bodyContents: `
           <div data-testid="target"></div>
@@ -575,8 +713,42 @@ describe("replaceAll", () => {
       });
 
       cy.document().then((document) => {
-        const textNode1 = document.createTextNode("Lorem   ");
-        const textNode2 = document.createTextNode("ipsum");
+        const textNode1 = document.createTextNode("Lorem");
+        const textNode2 = document.createTextNode("ipsum. dolor");
+        const target = document.querySelector("[data-testid='target']");
+
+        target?.appendChild(textNode1);
+        target?.appendChild(textNode2);
+
+        replaceAll(
+          [
+            {
+              active: true,
+              identifier: "ABCD-1234",
+              queries: ["Loremipsum"],
+              queryPatterns: ["wholeWord"],
+              replacement: "sit",
+              useGlobalReplacementStyle: DEFAULT_USE_GLOBAL_REPLACEMENT_STYLE,
+            },
+          ],
+          undefined,
+          document
+        );
+
+        s.target().should("have.text", "sit. dolor");
+      });
+    });
+
+    it("replaces text across adjacent text nodes for multiple-word queries", () => {
+      cy.visitMock({
+        bodyContents: `
+          <div data-testid="target"></div>
+        `,
+      });
+
+      cy.document().then((document) => {
+        const textNode1 = document.createTextNode("Lorem");
+        const textNode2 = document.createTextNode("ipsum. dolor");
         const target = document.querySelector("[data-testid='target']");
 
         target?.appendChild(textNode1);
@@ -597,7 +769,41 @@ describe("replaceAll", () => {
           document
         );
 
-        s.target().should("have.text", "sit");
+        s.target().should("have.text", "sit. dolor");
+      });
+    });
+
+    it("trims empty space around sibling elements when adjacent text nodes exist", () => {
+      cy.visitMock({
+        bodyContents: `
+          <div data-testid="target"></div>
+        `,
+      });
+
+      cy.document().then((document) => {
+        const textNode1 = document.createTextNode("Lorem   ");
+        const textNode2 = document.createTextNode("ipsum. dolor");
+        const target = document.querySelector("[data-testid='target']");
+
+        target?.appendChild(textNode1);
+        target?.appendChild(textNode2);
+
+        replaceAll(
+          [
+            {
+              active: true,
+              identifier: "ABCD-1234",
+              queries: ["Lorem ipsum"],
+              queryPatterns: ["wholeWord"],
+              replacement: "sit",
+              useGlobalReplacementStyle: DEFAULT_USE_GLOBAL_REPLACEMENT_STYLE,
+            },
+          ],
+          undefined,
+          document
+        );
+
+        s.target().should("have.text", "sit. dolor");
       });
     });
   });

--- a/packages/shared/src/replace/find-text.ts
+++ b/packages/shared/src/replace/find-text.ts
@@ -4,10 +4,10 @@ import { CONTENTS_PROPERTY } from "./lib";
 import { nodeNameBlocklist } from "./lib/dom";
 import { getRegexFlags, patternRegex } from "./lib/regex";
 
-function checkContainsText(
+function checkElementContent(
   content: string,
-  queryPatterns: QueryPattern[],
-  query: string
+  query: string,
+  queryPatterns: QueryPattern[]
 ) {
   if (!queryPatterns || queryPatterns.length < 1) {
     return patternRegex.default(query).test(content);
@@ -61,6 +61,62 @@ function getAdjacentTextNodes(node: Node): Text[] {
 }
 
 /**
+ * Makes several attempts at matching and returning matched text from a list of
+ * text nodes. If more than one element is provided, we have to test matching
+ * with and without spaces between each one's text content to allow matching on
+ * queries with more than one word.
+ */
+function getMatchedText(
+  elements: Text[],
+  query: string,
+  queryPatterns: QueryPattern[]
+): string | undefined {
+  if (elements.length === 0) {
+    return undefined;
+  }
+
+  function checkContent(content: string) {
+    return checkElementContent(content, query, queryPatterns);
+  }
+
+  if (elements.length === 1) {
+    const elementContents = String(elements[0][CONTENTS_PROPERTY]);
+    const matches = checkContent(elementContents);
+
+    return matches ? elementContents : undefined;
+  }
+
+  const contentsList = elements
+    .map((element) => element[CONTENTS_PROPERTY])
+    .filter((content) => content !== null);
+
+  if (contentsList.length === 0) {
+    return undefined;
+  }
+
+  if (contentsList.length === 1) {
+    const elementContents = contentsList[0];
+    const matches = checkContent(elementContents);
+
+    return matches ? elementContents : undefined;
+  }
+
+  const trimmedContents = contentsList.map((content) => content?.trim());
+
+  const spacedContents = trimmedContents.join(" ");
+  const spacedMatches = checkContent(spacedContents);
+
+  if (spacedMatches) return spacedContents;
+
+  const unspacedContents = trimmedContents.join("");
+  const unspacedMatches = checkContent(unspacedContents);
+
+  if (unspacedMatches) return unspacedContents;
+
+  return undefined;
+}
+
+/**
  * Recursively crawls an element in search of a given query and returns a list
  * of matching Text nodes.
  *
@@ -80,38 +136,23 @@ export function findText(
     const subsequentTextNodes = getAdjacentTextNodes(element);
     const isSubsequent = subsequentTextNodes.length > 1;
 
-    const elementContent = isSubsequent
-      ? /**
-         * Trim and merge all subsequent text nodes without spacing.
-         */
-        subsequentTextNodes
-          .map((node) => String(node[CONTENTS_PROPERTY]).trim())
-          .join("")
-      : /**
-         * Single text node, just get its own contents.
-         */
-        String(element[CONTENTS_PROPERTY]);
+    const matchedText = getMatchedText(
+      subsequentTextNodes,
+      query,
+      queryPatterns
+    );
+    const isAlreadyReplaced = Boolean(
+      element.parentElement?.dataset["isReplaced"]
+    );
+    const isParentAllowed = !nodeNameBlocklist.has(
+      String(element.parentNode?.nodeName.toLowerCase())
+    );
 
-    // TODO: Fix this for RegEx
-    const containsQuery = isSubsequent
-      ? /**
-         * More than one text node, remove all spacing from query.
-         */
-        query.replace(/\s+/g, "")
-      : /**
-         * Keep query as-is.
-         */
-        query;
-
-    if (
-      checkContainsText(elementContent, queryPatterns, containsQuery) &&
-      !element.parentElement?.dataset["isReplaced"] &&
-      !nodeNameBlocklist.has(String(element.parentNode?.nodeName.toLowerCase()))
-    ) {
-      // Update the element's text content
-      element.textContent = isSubsequent ? query : elementContent;
-
+    if (matchedText !== undefined && !isAlreadyReplaced && isParentAllowed) {
       if (isSubsequent) {
+        // Override the element's content with the text that matched.
+        element.textContent = matchedText;
+
         // Remove any following text nodes since they have been merged
         subsequentTextNodes.slice(1).forEach((node) => {
           node.remove();


### PR DESCRIPTION
## Major

- Modifies the recent changes to support adjacent text nodes to also support regular expression lookups

## Minor

- Removes a user groups lookup during content render that is not needed at this time - This should speed up replacements a little.
- Introduces unit tests to the content script's render method for the new rule groups feature