### PR TITLE
fix(shared): multiple mutations during replacement causing too many renders

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
     "name": "Dan Lovelace",
     "url": "https://github.com/dan-lovelace/word-replacer-max"
   },
-  "version": "0.14.0",
+  "version": "0.15.0",
   "license": "GPL-3.0-or-later",
   "description": "A browser extension for replacing text on web pages",
   "type": "module",

--- a/packages/shared/cypress/e2e/find-text.cy.ts
+++ b/packages/shared/cypress/e2e/find-text.cy.ts
@@ -83,7 +83,7 @@ describe("findText", () => {
       });
     });
 
-    it("merges adjacent text nodes into one", () => {
+    it.skip("merges adjacent text nodes into one", () => {
       cy.visitMock({
         targetContents: `
           <p></p>
@@ -107,7 +107,7 @@ describe("findText", () => {
       });
     });
 
-    it("trims empty space around adjacent text nodes before merging", () => {
+    it.skip("trims empty space around adjacent text nodes before merging", () => {
       cy.visitMock({
         targetContents: `
           <p></p>

--- a/packages/shared/cypress/e2e/replace-all.cy.ts
+++ b/packages/shared/cypress/e2e/replace-all.cy.ts
@@ -407,7 +407,7 @@ describe("replaceAll", () => {
       });
     });
 
-    it("replaces text across adjacent text nodes for single-word queries", () => {
+    it.skip("replaces text across adjacent text nodes for single-word queries", () => {
       cy.visitMock({
         bodyContents: `
           <div data-testid="target"></div>
@@ -441,7 +441,7 @@ describe("replaceAll", () => {
       });
     });
 
-    it("replaces text across adjacent text nodes for queries that contain a space", () => {
+    it.skip("replaces text across adjacent text nodes for queries that contain a space", () => {
       cy.visitMock({
         bodyContents: `
           <div data-testid="target"></div>
@@ -477,7 +477,7 @@ describe("replaceAll", () => {
   });
 
   describe("'case' query pattern only", () => {
-    it("replaces text across adjacent text nodes for single-word queries", () => {
+    it.skip("replaces text across adjacent text nodes for single-word queries", () => {
       cy.visitMock({
         bodyContents: `
           <div data-testid="target"></div>
@@ -511,7 +511,7 @@ describe("replaceAll", () => {
       });
     });
 
-    it("replaces text across adjacent text nodes for multiple-word queries", () => {
+    it.skip("replaces text across adjacent text nodes for multiple-word queries", () => {
       cy.visitMock({
         bodyContents: `
           <div data-testid="target"></div>
@@ -606,7 +606,7 @@ describe("replaceAll", () => {
         .should("match", /^Lorem <span[^>]*>sit<\/span> dolor$/);
     });
 
-    it("replaces text across adjacent text nodes for single-word queries", () => {
+    it.skip("replaces text across adjacent text nodes for single-word queries", () => {
       cy.visitMock({
         bodyContents: `
           <div data-testid="target"></div>
@@ -640,7 +640,7 @@ describe("replaceAll", () => {
       });
     });
 
-    it("replaces text across adjacent text nodes for multiple-word queries", () => {
+    it.skip("replaces text across adjacent text nodes for multiple-word queries", () => {
       cy.visitMock({
         bodyContents: `
           <div data-testid="target"></div>
@@ -705,7 +705,7 @@ describe("replaceAll", () => {
       });
     });
 
-    it("replaces text across adjacent text nodes for single-word queries", () => {
+    it.skip("replaces text across adjacent text nodes for single-word queries", () => {
       cy.visitMock({
         bodyContents: `
           <div data-testid="target"></div>
@@ -739,7 +739,7 @@ describe("replaceAll", () => {
       });
     });
 
-    it("replaces text across adjacent text nodes for multiple-word queries", () => {
+    it.skip("replaces text across adjacent text nodes for multiple-word queries", () => {
       cy.visitMock({
         bodyContents: `
           <div data-testid="target"></div>
@@ -773,7 +773,7 @@ describe("replaceAll", () => {
       });
     });
 
-    it("trims empty space around sibling elements when adjacent text nodes exist", () => {
+    it.skip("trims empty space around sibling elements when adjacent text nodes exist", () => {
       cy.visitMock({
         bodyContents: `
           <div data-testid="target"></div>

--- a/packages/shared/src/replace/find-text.ts
+++ b/packages/shared/src/replace/find-text.ts
@@ -4,127 +4,9 @@ import { CONTENTS_PROPERTY } from "./lib";
 import { nodeNameBlocklist } from "./lib/dom";
 import { getRegexFlags, patternRegex } from "./lib/regex";
 
-function checkElementContent(
-  content: string,
-  query: string,
-  queryPatterns: QueryPattern[]
-) {
-  if (!queryPatterns || queryPatterns.length < 1) {
-    return patternRegex.default(query).test(content);
-  }
-
-  let containsText = false;
-
-  /**
-   * This iterates through all given patterns exhaustively because of pattern
-   * precedence. For example, `wholeWord` failing to match will override a
-   * previous `case` match and return false. It is not acceptable to `some()`
-   * the patterns list.
-   */
-  for (const pattern of queryPatterns) {
-    switch (pattern) {
-      case "case":
-      case "default": {
-        containsText = patternRegex[pattern](query).test(content);
-        break;
-      }
-
-      case "regex":
-      case "wholeWord": {
-        containsText = patternRegex[pattern](
-          query,
-          getRegexFlags(queryPatterns)
-        ).test(content);
-        break;
-      }
-    }
-  }
-
-  return containsText;
-}
-
-function getAdjacentTextNodes(node: Node): Text[] {
-  const nodes: Text[] = [];
-  let currentNode: Node | null = node;
-
-  while (currentNode) {
-    if (currentNode.nodeType === Node.TEXT_NODE) {
-      nodes.push(currentNode as Text);
-    } else {
-      break;
-    }
-
-    currentNode = currentNode.nextSibling;
-  }
-
-  return nodes;
-}
-
-/**
- * Makes several attempts at matching and returning matched text from a list of
- * text nodes. If more than one element is provided, we have to test matching
- * with and without spaces between each one's text content to allow matching on
- * queries with more than one word.
- */
-function getMatchedText(
-  elements: Text[],
-  query: string,
-  queryPatterns: QueryPattern[]
-): string | undefined {
-  if (elements.length === 0) {
-    return undefined;
-  }
-
-  function checkContent(content: string) {
-    return checkElementContent(content, query, queryPatterns);
-  }
-
-  if (elements.length === 1) {
-    const elementContents = String(elements[0][CONTENTS_PROPERTY]);
-    const matches = checkContent(elementContents);
-
-    return matches ? elementContents : undefined;
-  }
-
-  const contentsList = elements
-    .map((element) => element[CONTENTS_PROPERTY])
-    .filter((content) => content !== null);
-
-  if (contentsList.length === 0) {
-    return undefined;
-  }
-
-  if (contentsList.length === 1) {
-    const elementContents = contentsList[0];
-    const matches = checkContent(elementContents);
-
-    return matches ? elementContents : undefined;
-  }
-
-  const trimmedContents = contentsList.map((content) => content?.trim());
-
-  const spacedContents = trimmedContents.join(" ");
-  const spacedMatches = checkContent(spacedContents);
-
-  if (spacedMatches) return spacedContents;
-
-  const unspacedContents = trimmedContents.join("");
-  const unspacedMatches = checkContent(unspacedContents);
-
-  if (unspacedMatches) return unspacedContents;
-
-  return undefined;
-}
-
 /**
  * Recursively crawls an element in search of a given query and returns a list
  * of matching Text nodes.
- *
- * @remarks
- * Also mutates chains of adjacent text nodes by merging them into a single
- * node and deleting all but the first. This is done in preparation of
- * replacment to support replacing text across text nodes that are beside each
- * other. See: https://github.com/dan-lovelace/word-replacer-max/issues/60.
  */
 export function findText(
   element: HTMLElement,
@@ -132,41 +14,51 @@ export function findText(
   queryPatterns: QueryPattern[],
   found: Text[] = []
 ) {
-  if (element.nodeType === Node.TEXT_NODE) {
-    const subsequentTextNodes = getAdjacentTextNodes(element);
-    const isSubsequent = subsequentTextNodes.length > 1;
+  const elementContents = String(element[CONTENTS_PROPERTY]);
+  let containsText = false;
 
-    const matchedText = getMatchedText(
-      subsequentTextNodes,
-      query,
-      queryPatterns
-    );
-    const isAlreadyReplaced = Boolean(
-      element.parentElement?.dataset["isReplaced"]
-    );
-    const isParentAllowed = !nodeNameBlocklist.has(
-      String(element.parentNode?.nodeName.toLowerCase())
-    );
+  if (!queryPatterns || queryPatterns.length < 1) {
+    // default query pattern
+    containsText = patternRegex.default(query).test(elementContents);
+  } else {
+    for (const pattern of queryPatterns) {
+      switch (pattern) {
+        case "case":
+        case "default": {
+          containsText = patternRegex[pattern](query).test(elementContents);
+          break;
+        }
 
-    if (matchedText !== undefined && !isAlreadyReplaced && isParentAllowed) {
-      if (isSubsequent) {
-        // Override the element's content with the text that matched.
-        element.textContent = matchedText;
-
-        // Remove any following text nodes since they have been merged
-        subsequentTextNodes.slice(1).forEach((node) => {
-          node.remove();
-        });
+        case "regex":
+        case "wholeWord": {
+          containsText = patternRegex[pattern](
+            query,
+            getRegexFlags(queryPatterns)
+          ).test(elementContents);
+          break;
+        }
       }
-
-      found.push(element as unknown as Text);
     }
-  } else if (element.hasChildNodes()) {
+  }
+
+  if (!containsText) {
+    return found;
+  }
+
+  if (element.hasChildNodes()) {
     const childElements = Array.from(element.childNodes) as HTMLElement[];
 
     for (const child of childElements) {
       findText(child, query, queryPatterns, found);
     }
+  }
+
+  if (
+    element.nodeType === Node.TEXT_NODE &&
+    !element.parentElement?.dataset["isReplaced"] &&
+    !nodeNameBlocklist.has(String(element.parentNode?.nodeName.toLowerCase()))
+  ) {
+    found.push(element as unknown as Text);
   }
 
   return found;


### PR DESCRIPTION
## Major

- Removes the ability to query across text nodes due to performance - A user reported in #57 they are experiencing slowness on YouTube since v0.12.0. Testing concluded it was in fact caused by the changes introduced to handle searching across adjacent text nodes. Resolves #65 