### PR TITLE
fix(shared): add noscript element to replacement blocklist

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
     "name": "Dan Lovelace",
     "url": "https://github.com/dan-lovelace/word-replacer-max"
   },
-  "version": "0.16.0",
+  "version": "0.17.0",
   "license": "GPL-3.0-or-later",
   "description": "A browser extension for replacing text on web pages",
   "type": "module",

--- a/packages/shared/src/replace/lib/dom.ts
+++ b/packages/shared/src/replace/lib/dom.ts
@@ -7,6 +7,7 @@ export const nodeNameBlocklist: Set<Node["nodeName"]> = new Set([
   "img",
   "link",
   "meta",
+  "noscript",
   "script",
   "style",
   "svg",


### PR DESCRIPTION
## Minor

- Adds `noscript` to the list of blocklist replacement elements - Resolves an issue on x.com