### PR TITLE
feat(webapp): initial import migrator

### DIFF
--- a/packages/webapp/src/App.tsx
+++ b/packages/webapp/src/App.tsx
@@ -9,6 +9,7 @@ import ThemeProvider from "@mui/material/styles/ThemeProvider";
 import Layout from "./containers/Layout";
 import { ROUTES } from "./lib/routes";
 import HomePage from "./pages/HomePage";
+import ImportMigratorPage from "./pages/ImportMigratorPage";
 import LoginCallbackPage from "./pages/LoginCallbackPage";
 import LoginPage from "./pages/LoginPage";
 import LoginSuccessPage from "./pages/LoginSuccessPage";
@@ -31,6 +32,7 @@ function AppRoutes() {
   return (
     <Routes>
       <Route path={ROUTES.HOME} element={<HomePage />} />
+      <Route path={ROUTES.IMPORT_MIGRATOR} element={<ImportMigratorPage />} />
       <Route path={ROUTES.LOGIN} element={<LoginPage />} />
       <Route path={ROUTES.LOGIN_CALLBACK} element={<LoginCallbackPage />} />
       <Route path={ROUTES.LOGIN_SUCCESS} element={<LoginSuccessPage />} />

--- a/packages/webapp/src/components/form/NewsletterSignup.tsx
+++ b/packages/webapp/src/components/form/NewsletterSignup.tsx
@@ -8,7 +8,6 @@ import Box from "@mui/material/Box/Box";
 import CircularProgress from "@mui/material/CircularProgress/CircularProgress";
 import Container from "@mui/material/Container/Container";
 import Fade from "@mui/material/Fade/Fade";
-import FormGroup from "@mui/material/FormGroup/FormGroup";
 import FormHelperText from "@mui/material/FormHelperText/FormHelperText";
 import InputAdornment from "@mui/material/InputAdornment/InputAdornment";
 import Stack from "@mui/material/Stack/Stack";

--- a/packages/webapp/src/lib/routes.ts
+++ b/packages/webapp/src/lib/routes.ts
@@ -1,5 +1,6 @@
 export const ROUTES = {
   HOME: "/",
+  IMPORT_MIGRATOR: "/import-migrator",
   LOGIN: "/login",
   LOGIN_CALLBACK: "/login/callback",
   LOGIN_SUCCESS: "/login/success",

--- a/packages/webapp/src/pages/ImportMigratorPage.tsx
+++ b/packages/webapp/src/pages/ImportMigratorPage.tsx
@@ -1,0 +1,207 @@
+import { useState } from "react";
+
+import { v4 as uuidv4 } from "uuid";
+
+import Alert from "@mui/material/Alert/Alert";
+import Box from "@mui/material/Box/Box";
+import Container from "@mui/material/Container/Container";
+import Stack from "@mui/material/Stack/Stack";
+import TextField from "@mui/material/TextField/TextField";
+
+import { QueryPattern } from "@worm/types/src/replace";
+import { Matcher } from "@worm/types/src/rules";
+import { SchemaExport } from "@worm/types/src/storage";
+
+import Button from "../components/button/Button";
+
+interface FoxReplaceExport {
+  version: string;
+  groups: FoxReplaceExportGroup[];
+}
+
+interface FoxReplaceExportGroup {
+  enabled: boolean;
+  html: "inputoutput" | "output" | "none";
+  mode: FoxReplaceGroupMode;
+  name: string;
+  substitutions: FoxReplaceSubstitution[];
+  urls: string[];
+}
+
+interface FoxReplaceSubstitution {
+  caseSensitive: boolean;
+  input: string;
+  inputType: FoxReplaceSubstitutionType;
+  output: string;
+  outputType: FoxReplaceSubstitutionType;
+}
+
+interface MigratorFormData {
+  error: string;
+  input: string;
+  output: string;
+}
+
+type FoxReplaceGroupMode = "auto" | "auto&manual" | "manual";
+
+type FoxReplaceSubstitutionType = "regexp" | "text" | "wholewords";
+
+const defaultFormData: MigratorFormData = {
+  error: "",
+  input: "",
+  output: "",
+};
+
+const foxReplaceQueryPatternMapping: Record<
+  FoxReplaceSubstitutionType,
+  QueryPattern
+> = {
+  regexp: "regex",
+  text: "default",
+  wholewords: "wholeWord",
+};
+
+function convert(input: string): Pick<MigratorFormData, "error" | "output"> {
+  let error = "",
+    output = "";
+
+  try {
+    const inputJson: FoxReplaceExport = JSON.parse(input);
+    const wrmOutput: SchemaExport = {
+      version: 1,
+      data: {
+        matchers: [],
+      },
+    };
+
+    for (const group of inputJson.groups) {
+      const { substitutions } = group;
+
+      for (const substitution of substitutions) {
+        const newMatcher: Matcher = {
+          active: true,
+          identifier: uuidv4(),
+          queries: [substitution.input],
+          queryPatterns: [],
+          replacement: substitution.output,
+        };
+
+        if (substitution.caseSensitive) {
+          newMatcher.queryPatterns.push("case");
+        }
+
+        switch (substitution.inputType) {
+          case "regexp":
+          case "wholewords":
+            newMatcher.queryPatterns.push(
+              foxReplaceQueryPatternMapping[substitution.inputType]
+            );
+            break;
+
+          default:
+            if (newMatcher.queryPatterns.length === 0) {
+              newMatcher.queryPatterns.push("default");
+            }
+        }
+
+        wrmOutput.data?.matchers?.push(newMatcher);
+      }
+    }
+
+    output = JSON.stringify(wrmOutput);
+  } catch (e) {
+    console.error("Error converting", e);
+
+    error =
+      e instanceof Error
+        ? e.message
+        : "Something went wrong, check the console";
+  }
+
+  return {
+    error,
+    output,
+  };
+}
+
+export default function ImportMigratorPage() {
+  const [formData, setFormData] = useState<MigratorFormData>(defaultFormData);
+
+  const handleDownloadClick = () => {
+    const href = `data:text/json;charset=utf-8,${encodeURIComponent(
+      formData.output
+    )}`;
+    const anchor = document.createElement("a");
+    const filename = `WordReplacerMax_Rules_${new Date().getTime()}.json`;
+
+    anchor.setAttribute("href", href);
+    anchor.setAttribute("download", filename);
+    document.body.appendChild(anchor);
+    anchor.click();
+    anchor.remove();
+  };
+
+  const handleInputChange = (
+    event: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>
+  ) => {
+    setFormData({
+      ...formData,
+      [event.target.name]: event.target.value,
+    });
+  };
+
+  const handleFormSubmit = (event: React.FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+
+    setFormData({
+      ...formData,
+      ...convert(formData.input),
+    });
+  };
+
+  return (
+    <>
+      <Container sx={{ py: 4 }}>
+        <h1>FoxReplace Migrator</h1>
+        <p>
+          Use the form below to translate FoxReplace exports to Word Replacer
+          Max.
+        </p>
+        <Box sx={{ py: 3 }}>
+          <form onSubmit={handleFormSubmit}>
+            <Stack gap={2}>
+              <TextField
+                fullWidth
+                multiline
+                name="input"
+                placeholder="Paste your FoxReplace export JSON here"
+                rows={8}
+                value={formData.input}
+                onChange={handleInputChange}
+              />
+              {formData.error && (
+                <Alert severity="error">{formData.error}</Alert>
+              )}
+              <Button disabled={!formData.input} type="submit">
+                Convert
+              </Button>
+              <TextField
+                disabled
+                fullWidth
+                label="Output"
+                multiline
+                name="output"
+                rows={8}
+                value={formData.output}
+                onChange={handleInputChange}
+              />
+              <Button disabled={!formData.output} onClick={handleDownloadClick}>
+                Download
+              </Button>
+            </Stack>
+          </form>
+        </Box>
+      </Container>
+    </>
+  );
+}


### PR DESCRIPTION
## Minor

- Adds an "Import Migrator" utility to the webapp located at https://wordreplacermax.com/import-migrator

## Assets

![Screenshot 2025-06-15 at 11 03 14 AM](https://github.com/user-attachments/assets/d21260b1-aba8-413c-80ab-9705783dc634)