### PR TITLE
feat(popup): add rule to active groups upon creation

### DIFF
--- a/packages/popup/cypress/e2e/home-page/rule-groups.cy.ts
+++ b/packages/popup/cypress/e2e/home-page/rule-groups.cy.ts
@@ -614,4 +614,56 @@ describe("home page rule groups", () => {
       });
     });
   });
+
+  describe("rules list", () => {
+    describe("functionality", () => {
+      const testMatcherGroups: MatcherGroupInSync = {
+        [TEST_GROUP_ID_1]: {
+          active: false,
+          color: "red",
+          identifier: "1234",
+          matchers: [testRules[TEST_MATCHER_ID_1].identifier],
+          name: "Override Group 1",
+        },
+        [TEST_GROUP_ID_2]: {
+          active: false,
+          color: "green",
+          identifier: "5678",
+          matchers: [testRules[TEST_MATCHER_ID_2].identifier],
+          name: "Override Group 2",
+        },
+      };
+
+      beforeEach(() => {
+        cy.visitWithStorage({
+          sync: {
+            ...generateMatcherGroups(testMatcherGroups),
+            ruleGroups: {
+              active: true,
+            },
+          },
+        });
+      });
+
+      it("should add new rules to the selected group when one is selected", () => {
+        selectors.ruleGroups.toolbar.groupToggles().eq(0).click();
+        selectors.ruleRows().should("have.length", 1);
+
+        selectors.addNewRuleButton().click();
+        selectors.ruleRows().should("have.length", 2);
+      });
+
+      it("should add new rules to the selected group when more than one is selected", () => {
+        selectors.ruleGroups.toolbar.groupToggles().eq(0).click();
+        selectors.ruleGroups.toolbar
+          .groupToggles()
+          .eq(1)
+          .click({ ctrlKey: true });
+        selectors.ruleRows().should("have.length", 2);
+
+        selectors.addNewRuleButton().click();
+        selectors.ruleRows().should("have.length", 3);
+      });
+    });
+  });
 });

--- a/packages/popup/src/components/rules/RuleList.tsx
+++ b/packages/popup/src/components/rules/RuleList.tsx
@@ -37,7 +37,7 @@ export default function RuleList() {
       <div className={cx(canGroupRules ? "pt-1" : "pt-2")}>
         {matchers?.length ? (
           <>
-            <div className="row gx-3 gy-2" data-testid="rule-list-wrapper">
+            <div className="row gx-3 gy-2 pb-1" data-testid="rule-list-wrapper">
               {renderedMatchers?.map((matcher) => (
                 <div
                   key={matcher.identifier}
@@ -54,7 +54,7 @@ export default function RuleList() {
               data-testid="rule-list-actions"
             >
               <div
-                className="bg-body py-2"
+                className="bg-body pt-1 pb-2"
                 style={{
                   paddingLeft: 55,
                   marginLeft: "-12px",


### PR DESCRIPTION
## Minor

- Improves the rule groups experience by keeping the selected group(s) active when adding a new rule instead of returning the user to the list of all rules

## Assets

https://github.com/user-attachments/assets/48fb7213-987c-441a-bff8-4495e29ef5e1