### PR TITLE
fix(popup): unconditionally apply document color mode

### DIFF
--- a/packages/popup/src/index.tsx
+++ b/packages/popup/src/index.tsx
@@ -47,10 +47,7 @@ export function App() {
         });
       }
 
-      if (colorMode) {
-        updateDocumentColorMode(getCurrentColorMode(colorMode));
-      }
-
+      updateDocumentColorMode(getCurrentColorMode(colorMode));
       setIsInitialized(true);
     }
 


### PR DESCRIPTION
## Minor

- Instead of checking for an existing stored color mode, the Popup's initialization pipeline now applies a color mode no matter what (see note below)

## Assets

|User report|
|-|
|<img width="1002" height="752" alt="screenshot" src="https://github.com/user-attachments/assets/7086ce8e-ea38-424c-a686-6b74dfca9fce" />|

## Notes

Some time after releasing 0.19.0, something changed with Chrome's strictness around its storage API calls and migrations were failing to run. Included in the migrations was a preference addition of the user's chosen color mode for the Popup. With the migration having never run, an issue arose where some Popup components rendered in dark mode and some in light mode.