### PR TITLE
feat(replace): option to toggle automatic input replacements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ versions
 
 # Cypress
 downloads/
+**/*/cypress/screenshots/

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
     "name": "Dan Lovelace",
     "url": "https://github.com/dan-lovelace/word-replacer-max"
   },
-  "version": "0.20.0",
+  "version": "0.21.0",
   "license": "GPL-3.0-or-later",
   "description": "A browser extension for replacing text on web pages",
   "type": "module",

--- a/packages/background/src/lib/storage.ts
+++ b/packages/background/src/lib/storage.ts
@@ -4,6 +4,7 @@ import {
   matchersFromStorage,
   matchersToStorage,
 } from "@worm/shared/src/browser";
+import { DEFAULT_INPUT_REPLACE } from "@worm/shared/src/replace/lib/input-replace";
 import { DEFAULT_RULE_SYNC } from "@worm/shared/src/replace/lib/rule-sync";
 import { DEFAULT_USE_GLOBAL_REPLACEMENT_STYLE } from "@worm/shared/src/replace/lib/style";
 import {
@@ -89,6 +90,7 @@ export async function initializeStorage() {
         field: "replacement",
         matcher: "",
       },
+      inputReplacement: DEFAULT_INPUT_REPLACE,
     };
   }
 

--- a/packages/popup/cypress/support/selectors.ts
+++ b/packages/popup/cypress/support/selectors.ts
@@ -110,7 +110,8 @@ export const selectors = {
         closeButton: () => cy.findByTestId("sync-confirm-modal-close-button"),
         confirmationAlert: () =>
           cy.findByTestId("rule-sync-confirmation-alert"),
-        confirmationCheckbox: () => cy.findByTestId("confirmation-checkbox"),
+        confirmationCheckbox: () =>
+          cy.findByTestId("rule-sync-confirmation-checkbox"),
         proceedButton: () => cy.findByRole("button", { name: /proceed/i }),
         root: () => cy.findByTestId("sync-confirm-modal"),
         sharingTabButton: () => cy.findByTestId("sharing-tab-button"),

--- a/packages/popup/src/components/options/InputReplacement.tsx
+++ b/packages/popup/src/components/options/InputReplacement.tsx
@@ -280,17 +280,17 @@ export default function InputReplacement() {
                 <div className="form-check">
                   <label
                     className="user-select-none"
-                    htmlFor="confirmation-checkbox"
+                    htmlFor="input-replacement-confirmation-checkbox"
                   >
                     I understand and accept the risks
                   </label>
                   <input
                     checked={confirmStatus === "confirmed"}
                     className="form-check-input"
-                    id="confirmation-checkbox"
+                    id="input-replacement-confirmation-checkbox"
                     type="checkbox"
                     onChange={handleConfirmChange}
-                    data-testid="confirmation-checkbox"
+                    data-testid="input-replacement-confirmation-checkbox"
                   />
                 </div>
               </Alert>

--- a/packages/popup/src/components/options/InputReplacement.tsx
+++ b/packages/popup/src/components/options/InputReplacement.tsx
@@ -272,8 +272,8 @@ export default function InputReplacement() {
                   unexpectedly.
                 </p>
                 <p>
-                  Additionally, it could also result in the submission of false
-                  or incorrect data in things like web forms, emails and
+                  Additionally, it could result in the submission of false or
+                  incorrect data in things like web forms, emails and
                   spreadsheets.
                 </p>
 

--- a/packages/popup/src/components/options/InputReplacement.tsx
+++ b/packages/popup/src/components/options/InputReplacement.tsx
@@ -1,4 +1,7 @@
-import { useEffect, useState } from "preact/hooks";
+import { useEffect, useRef, useState } from "preact/hooks";
+import { JSXInternal } from "preact/src/jsx";
+
+import { Modal } from "bootstrap";
 
 import {
   getCommandShortcut,
@@ -6,14 +9,39 @@ import {
   parseShortcutKeys,
   ShortcutKey,
 } from "@worm/shared/src/browser";
+import { DEFAULT_INPUT_REPLACE } from "@worm/shared/src/replace/lib/input-replace";
+import { storageSetByKeys } from "@worm/shared/src/storage";
+import { InputReplacementMode } from "@worm/types/src/replace";
 
 import { Indented } from "../../containers/Indented";
+import { useLanguage } from "../../lib/language";
+import { useConfig } from "../../store/Config";
 
+import { useToast } from "../alert/useToast";
+import Alert from "../Alerts";
+import Button from "../button/Button";
 import TextButton from "../button/TextButton";
+import Slide from "../transition/Slide";
+
+type ConfirmState = "idle" | "confirmed" | "confirming";
+
+const MODAL_ID = "real-time-confirm";
 
 export default function InputReplacement() {
+  const [confirmStatus, setConfirmStatus] = useState<ConfirmState>("idle");
   const [shortcutKeys, setShortcutKeys] = useState<ShortcutKey[]>([]);
 
+  const {
+    storage: {
+      sync: { preferences },
+    },
+  } = useConfig();
+  const { showRefreshToast } = useToast();
+
+  const hideModalButtonRef = useRef<HTMLButtonElement>(null);
+  const modalRef = useRef<Modal>();
+
+  const isActive = !!preferences?.inputReplacement?.active;
   const shortcutExists = shortcutKeys.length > 0;
 
   useEffect(() => {
@@ -22,32 +50,269 @@ export default function InputReplacement() {
     });
   }, []);
 
+  useEffect(() => {
+    const modalElement = document.getElementById(MODAL_ID);
+
+    if (!modalElement) {
+      throw new Error("Unable to find modal element");
+    }
+
+    const closeListener = () => {
+      setConfirmStatus("idle");
+    };
+
+    modalElement.addEventListener("hide.bs.modal", closeListener);
+
+    const modal = new Modal(modalElement);
+
+    modalRef.current = modal;
+
+    return () => {
+      modalElement.removeEventListener("hide.bs.modal", closeListener);
+      modal.dispose();
+    };
+  }, []);
+
+  const handleActiveChange = (
+    event: JSXInternal.TargetedEvent<HTMLInputElement, Event>
+  ) => {
+    const newPreferences = Object.assign({}, preferences);
+    const newInputReplacement = Object.assign(
+      {},
+      newPreferences.inputReplacement
+    );
+    const newValue = event.currentTarget.checked;
+
+    newInputReplacement.active = newValue;
+
+    if (!newValue) {
+      // reset to default mode when disabling
+      newInputReplacement.mode = DEFAULT_INPUT_REPLACE.mode;
+    }
+
+    newPreferences.inputReplacement = newInputReplacement;
+
+    storageSetByKeys({ preferences: newPreferences });
+    showRefreshToast();
+  };
+
+  const handleConfirm = () => {
+    updateMode("real-time");
+    modalRef.current?.hide();
+
+    showRefreshToast();
+  };
+
+  const handleConfirmChange = (
+    event: JSXInternal.TargetedEvent<HTMLInputElement, Event>
+  ) => {
+    setConfirmStatus(event.currentTarget.checked ? "confirmed" : "confirming");
+  };
+
+  const handleModeChange = (newMode: InputReplacementMode) => () => {
+    updateMode(newMode);
+  };
+
+  const handleRealTimeClick = (event: MouseEvent) => {
+    if (preferences?.inputReplacement?.mode !== "real-time") {
+      event.preventDefault();
+      modalRef.current?.show();
+    }
+  };
+
+  const updateMode = (newMode: InputReplacementMode) => {
+    const newPreferences = Object.assign({}, preferences);
+    const newInputReplacement = Object.assign(
+      {},
+      newPreferences.inputReplacement
+    );
+
+    newInputReplacement.mode = newMode;
+    newPreferences.inputReplacement = newInputReplacement;
+
+    storageSetByKeys({ preferences: newPreferences });
+  };
+
   return (
-    <div className="input-replacement">
-      <Indented data-testid="input-replacement-description">
-        <div className="fw-medium">Replace text where you type</div>
-        <div className="fs-sm">
-          Replacements don't run automatically in text fields or rich-text
-          editors. Use a keyboard shortcut to apply them on demand.
+    <>
+      <div className="input-replacement">
+        <div
+          className="form-check form-switch ps-0 d-flex align-items-center gap-2"
+          data-testid="input-replacement-input-wrapper"
+        >
+          <input
+            checked={isActive}
+            className="form-check-input m-0"
+            data-testid="input-replacement-toggle-button"
+            id="input-replacement-enabled-checkbox"
+            role="switch"
+            type="checkbox"
+            onChange={handleActiveChange}
+          />
+          <label
+            className="form-check-label user-select-none fw-medium"
+            for="input-replacement-enabled-checkbox"
+          >
+            Replace text where I type
+          </label>
         </div>
-        <div className="d-flex align-items-center gap-2 mt-2 fs-sm">
-          <div className="d-flex align-items-center gap-1">
-            <span>Shortcut:</span>
-            {shortcutExists ? (
-              <>
-                {shortcutKeys.map((key) => (
-                  <kbd key={key}>{key}</kbd>
-                ))}
-              </>
-            ) : (
-              <span className="text-muted fst-italic">None</span>
-            )}
+        <Slide isOpen={!isActive}>
+          <Indented data-testid="input-replacement-description">
+            <div className="fs-sm">
+              By default, replacements only run on page text. Turn this on to
+              also replace text in search boxes, forms, and other inputs.
+            </div>
+          </Indented>
+        </Slide>
+        <Slide isOpen={isActive}>
+          <Indented className="py-1" data-testid="input-replacement-options">
+            <div className="d-flex flex-column gap-1">
+              <div
+                className="border rounded form-check m-0 pe-3 py-2"
+                style={{ paddingLeft: "2.5rem" }}
+              >
+                <input
+                  checked={preferences?.inputReplacement?.mode === "on-demand"}
+                  className="form-check-input"
+                  id="onDemandRadio"
+                  name="on-demand"
+                  type="radio"
+                  onChange={handleModeChange("on-demand")}
+                />
+                <label
+                  className="form-check-label"
+                  for="onDemandRadio"
+                  data-testid="on-demand-radio-button"
+                >
+                  When I press a key combination
+                </label>
+                <div className="fs-sm">
+                  <div className="mb-3">
+                    Replacements run only when you trigger them manually.
+                  </div>
+                  <div className="d-flex align-items-center gap-2 fs-sm">
+                    <div className="d-flex align-items-center gap-1">
+                      <span>Shortcut:</span>
+                      {shortcutExists ? (
+                        <>
+                          {shortcutKeys.map((key) => (
+                            <kbd key={key}>{key}</kbd>
+                          ))}
+                        </>
+                      ) : (
+                        <span className="text-muted fst-italic">None</span>
+                      )}
+                    </div>
+                    <TextButton onClick={openShortcutSettings}>
+                      {shortcutExists ? "Change" : "Set a shortcut"}
+                    </TextButton>
+                  </div>
+                </div>
+              </div>
+              <div
+                className="border rounded form-check m-0 pe-3 py-2"
+                style={{ paddingLeft: "2.5rem" }}
+              >
+                <input
+                  checked={preferences?.inputReplacement?.mode === "real-time"}
+                  className="form-check-input"
+                  id="realTimeRadio"
+                  name="real-time"
+                  type="radio"
+                  onChange={handleModeChange("real-time")}
+                  onClick={handleRealTimeClick}
+                />
+                <label
+                  className="form-check-label"
+                  for="realTimeRadio"
+                  data-testid="real-time-radio-button"
+                >
+                  All the time <strong>(unstable)</strong>
+                </label>
+                <div className="fs-sm">
+                  Replacements run in real time on page load and every
+                  keystroke.
+                </div>
+              </div>
+            </div>
+          </Indented>
+        </Slide>
+      </div>
+
+      <div
+        aria-hidden="true"
+        aria-labelledby="real-time-confirm-label"
+        className="modal fade"
+        data-testid="real-time-confirm"
+        id={MODAL_ID}
+      >
+        <div className="modal-dialog">
+          <div className="modal-content">
+            <div className="modal-header">
+              <h1 className="modal-title fs-5" id="real-time-confirm-label">
+                Confirmation
+              </h1>
+              <button
+                aria-label="Close"
+                className="btn-close"
+                data-bs-dismiss="modal"
+                ref={hideModalButtonRef}
+                type="button"
+              />
+            </div>
+            <div className="modal-body">
+              <Alert
+                severity="danger"
+                title="Important: Review before enabling"
+                data-testid="input-replacment-confirmation-alert"
+              >
+                <p>
+                  Replacements apply instantly as you type. This feature is not
+                  stable and may lead to the text cursor moving around
+                  unexpectedly.
+                </p>
+                <p>
+                  Additionally, it could also result in the submission of false
+                  or incorrect data in things like web forms, emails and
+                  spreadsheets.
+                </p>
+
+                <div className="form-check">
+                  <label
+                    className="user-select-none"
+                    htmlFor="confirmation-checkbox"
+                  >
+                    I understand and accept the risks
+                  </label>
+                  <input
+                    checked={confirmStatus === "confirmed"}
+                    className="form-check-input"
+                    id="confirmation-checkbox"
+                    type="checkbox"
+                    onChange={handleConfirmChange}
+                    data-testid="confirmation-checkbox"
+                  />
+                </div>
+              </Alert>
+            </div>
+            <div className="modal-footer">
+              <Button
+                data-bs-dismiss="modal"
+                data-testid="input-replacement-confirm-modal-cancel-button"
+              >
+                Cancel
+              </Button>
+              <Button
+                className="btn btn-primary"
+                disabled={confirmStatus !== "confirmed"}
+                onClick={handleConfirm}
+              >
+                Proceed
+              </Button>
+            </div>
           </div>
-          <TextButton onClick={openShortcutSettings}>
-            {shortcutExists ? "Change" : "Set a shortcut"}
-          </TextButton>
         </div>
-      </Indented>
-    </div>
+      </div>
+    </>
   );
 }

--- a/packages/popup/src/components/options/InputReplacement.tsx
+++ b/packages/popup/src/components/options/InputReplacement.tsx
@@ -227,11 +227,11 @@ export default function InputReplacement() {
                   for="realTimeRadio"
                   data-testid="real-time-radio-button"
                 >
-                  All the time <strong>(unstable)</strong>
+                  Automatically <strong>(unstable)</strong>
                 </label>
                 <div className="fs-sm">
-                  Replacements run in real time on page load and every
-                  keystroke.
+                  Replacements run immediately on page load and periodically
+                  afterward.
                 </div>
               </div>
             </div>
@@ -250,7 +250,7 @@ export default function InputReplacement() {
           <div className="modal-content">
             <div className="modal-header">
               <h1 className="modal-title fs-5" id="real-time-confirm-label">
-                Confirmation
+                Are you sure?
               </h1>
               <button
                 aria-label="Close"
@@ -261,20 +261,22 @@ export default function InputReplacement() {
               />
             </div>
             <div className="modal-body">
+              <p>
+                Automatic replacement in text inputs is experimental and not
+                recommended. Acknowledge the risks below to continue.
+              </p>
               <Alert
                 severity="danger"
-                title="Important: Review before enabling"
                 data-testid="input-replacment-confirmation-alert"
               >
                 <p>
-                  Replacements apply instantly as you type. This feature is not
-                  stable and may lead to the text cursor moving around
-                  unexpectedly.
+                  This feature is not stable and, depending on your rules, may
+                  lead to the text cursor moving around unexpectedly as you
+                  type.
                 </p>
                 <p>
-                  Additionally, it could result in the submission of false or
-                  incorrect data in things like web forms, emails and
-                  spreadsheets.
+                  Additionally, it could result in the submission of incorrect
+                  data in web forms, emails, and spreadsheets.
                 </p>
 
                 <div className="form-check">

--- a/packages/popup/src/components/options/RuleSync.tsx
+++ b/packages/popup/src/components/options/RuleSync.tsx
@@ -291,17 +291,17 @@ export default function RuleSync({}: RuleSyncProps) {
                 <div className="form-check">
                   <label
                     className="user-select-none"
-                    for="confirmation-checkbox"
+                    htmlFor="rule-sync-confirmation-checkbox"
                   >
                     {language.ruleSync.warningModal.CONFIRM_CHECKBOX_LABEL}
                   </label>
                   <input
                     checked={isConfirmed}
                     className="form-check-input"
-                    id="confirmation-checkbox"
+                    id="rule-sync-confirmation-checkbox"
                     type="checkbox"
                     onChange={handleIsConfirmedChange}
-                    data-testid="confirmation-checkbox"
+                    data-testid="rule-sync-confirmation-checkbox"
                   />
                 </div>
               </Alert>

--- a/packages/shared/__test__/__snapshots__/storage-migration.test.ts.snap
+++ b/packages/shared/__test__/__snapshots__/storage-migration.test.ts.snap
@@ -211,6 +211,10 @@ exports[`runStorageMigrations works with extension version v0.6.2 storage 1`] = 
       "field": "replacement",
       "matcher": "",
     },
+    "inputReplacement": {
+      "active": false,
+      "mode": "on-demand",
+    },
   },
   "renderRate": {
     "active": false,
@@ -230,6 +234,6 @@ exports[`runStorageMigrations works with extension version v0.6.2 storage 1`] = 
   "ruleSync": {
     "active": true,
   },
-  "storageVersion": "1.5.0",
+  "storageVersion": "1.6.0",
 }
 `;

--- a/packages/shared/cypress/e2e/render-content.cy.ts
+++ b/packages/shared/cypress/e2e/render-content.cy.ts
@@ -7,172 +7,336 @@ import { RenderRate } from "@worm/types/src/rules";
 import { DEFAULT_RENDER_RATE_MS } from "../../src/replace/lib/render";
 
 import { selectors } from "../support/selectors";
+import { InputReplacement } from "@worm/types/src/replace";
+import { SyncStorage } from "@worm/types/src/storage";
 
 const browser = testBrowser as Browser;
 
 describe("render content", () => {
-  beforeEach(() => {
-    browser.storage.sync.set({
-      matcher__1234: {
-        active: true,
-        identifier: "1234",
-        queries: ["ipsum"],
-        queryPatterns: [],
-        replacement: "sit",
-      },
-    });
-
-    cy.visitMock({
-      targetContents: "Lorem ipsum dolor",
-    });
-
-    cy.wait(50);
-  });
-
-  it("re-runs replacements when page content changes", () => {
-    cy.document().then(($doc) => {
-      const renderer = new Renderer(browser, $doc.documentElement);
-
-      // wait for document ready state render
-      cy.wait(DEFAULT_RENDER_RATE_MS + 10);
-
-      // change the target element's text to trigger a mutation observer event
-      selectors.target().then(($target) => {
-        $target[0].textContent = "Lorem ipsum dolor sit";
+  describe("non-input elements", () => {
+    beforeEach(() => {
+      browser.storage.sync.set({
+        matcher__1234: {
+          active: true,
+          identifier: "1234",
+          queries: ["ipsum"],
+          queryPatterns: [],
+          replacement: "sit",
+        },
       });
 
-      // this runs before the mutation occurs, ensure it hasn't been replaced yet
-      selectors
-        .target()
-        .contains("Lorem ipsum dolor sit")
-        .then(() => {
-          expect(renderer.renderCount).to.equal(1);
+      cy.visitMock({
+        targetContents: "Lorem ipsum dolor",
+      });
+
+      cy.wait(50);
+    });
+
+    it("re-runs replacements when page content changes", () => {
+      cy.document().then(($doc) => {
+        const renderer = new Renderer(browser, $doc.documentElement);
+
+        // wait for document ready state render
+        cy.wait(DEFAULT_RENDER_RATE_MS + 10);
+
+        // change the target element's text to trigger a mutation observer event
+        selectors.target().then(($target) => {
+          $target[0].textContent = "Lorem ipsum dolor sit";
         });
 
-      // use cypress inherent waits to wait for the mutation
-      selectors
-        .target()
-        .contains("Lorem sit dolor sit")
-        .then(() => {
-          expect(renderer.renderCount).to.equal(2);
-        });
+        // this runs before the mutation occurs, ensure it hasn't been replaced yet
+        selectors
+          .target()
+          .contains("Lorem ipsum dolor sit")
+          .then(() => {
+            expect(renderer.renderCount).to.equal(1);
+          });
+
+        // use cypress inherent waits to wait for the mutation
+        selectors
+          .target()
+          .contains("Lorem sit dolor sit")
+          .then(() => {
+            expect(renderer.renderCount).to.equal(2);
+          });
+      });
+    });
+
+    it("runs replacements on page load", async () => {
+      cy.document().then(($doc) => {
+        new Renderer(browser, $doc.documentElement);
+
+        selectors.target().contains("Lorem sit dolor");
+      });
+    });
+
+    it("does not re-run replacements faster than user preferences", () => {
+      const testFrequency = 200;
+
+      const newRenderRate: RenderRate = {
+        active: true,
+        frequency: testFrequency,
+      };
+
+      cy.document().then(($doc) => {
+        const renderer = new Renderer(browser, $doc.documentElement);
+
+        // updating storage renders content immediately - Call 1
+        browser.storage.sync
+          .set({
+            renderRate: newRenderRate,
+          })
+          .then(() => {
+            // change the target element's text to trigger a mutation observer event - Call 2
+            selectors.target().then(($target) => {
+              $target[0].textContent = "An updated string";
+            });
+
+            const start = Date.now();
+
+            // this runs before the mutation occurs, ensure it hasn't been replaced yet
+            selectors
+              .target()
+              .contains("An updated string")
+              .then(() => {
+                expect(renderer.renderCount).to.equal(2);
+              });
+
+            // change text again faster than test frequency - No call!
+            selectors.target().then(($target) => {
+              $target[0].textContent = "Lorem ipsum dolor sit";
+            });
+
+            // use cypress inherent waits to wait for the mutation - Call 3
+            selectors
+              .target()
+              .contains("Lorem sit dolor sit")
+              .then(() => {
+                expect(renderer.renderCount).to.equal(3);
+
+                const end = Date.now();
+                const total = end - start;
+
+                expect(total).greaterThan(testFrequency);
+              });
+          });
+      });
+    });
+
+    it("does not use user frequency preferences when feature is disabled", () => {
+      const testFrequency = 200;
+
+      const newRenderRate: RenderRate = {
+        active: false,
+        frequency: testFrequency,
+      };
+
+      cy.document().then(($doc) => {
+        const renderer = new Renderer(browser, $doc.documentElement);
+
+        // updating storage renders content immediately - Call 1
+        browser.storage.sync
+          .set({
+            renderRate: newRenderRate,
+          })
+          .then(() => {
+            // change the target element's text to trigger a mutation observer event - Call 2
+            selectors.target().then(($target) => {
+              $target[0].textContent = "An updated string";
+            });
+
+            const start = Date.now();
+
+            // this runs before the mutation occurs, ensure it hasn't been replaced yet
+            selectors
+              .target()
+              .contains("An updated string")
+              .then(() => {
+                expect(renderer.renderCount).to.equal(2);
+              });
+
+            // wait the default amount of time plus a little
+            cy.wait(DEFAULT_RENDER_RATE_MS + 10);
+
+            // change text again faster than test frequency - Call 3
+            selectors.target().then(($target) => {
+              $target[0].textContent = "Lorem ipsum dolor sit";
+            });
+
+            // use cypress inherent waits to wait for the mutation - Call 4
+            selectors
+              .target()
+              .contains("Lorem sit dolor sit")
+              .then(() => {
+                expect(renderer.renderCount).to.equal(4);
+
+                const end = Date.now();
+                const total = end - start;
+
+                expect(total).lessThan(testFrequency);
+              });
+          });
+      });
     });
   });
 
-  it("runs replacements on page load", async () => {
-    cy.document().then(($doc) => {
-      new Renderer(browser, $doc.documentElement);
-
-      selectors.target().contains("Lorem sit dolor");
-    });
-  });
-
-  it("does not re-run replacements faster than user preferences", () => {
-    const testFrequency = 200;
-
-    const newRenderRate: RenderRate = {
-      active: true,
-      frequency: testFrequency,
+  describe("input replacements", () => {
+    const defaultPreferences: SyncStorage["preferences"] = {
+      activeTab: "rules",
+      focusRule: {
+        field: "replacement",
+        matcher: "",
+      },
+      domainListEffect: "deny",
+      extensionEnabled: true,
+      inputReplacement: {
+        active: true,
+        mode: "real-time",
+      },
     };
 
-    cy.document().then(($doc) => {
-      const renderer = new Renderer(browser, $doc.documentElement);
+    it("replaces text inputs on page load when the preference is active", () => {
+      browser.storage.sync.set({
+        matcher__1234: {
+          active: true,
+          identifier: "1234",
+          queries: ["ipsum"],
+          queryPatterns: [],
+          replacement: "sit",
+        },
+        preferences: defaultPreferences,
+      });
 
-      // updating storage renders content immediately - Call 1
-      browser.storage.sync
-        .set({
-          renderRate: newRenderRate,
-        })
-        .then(() => {
-          // change the target element's text to trigger a mutation observer event - Call 2
-          selectors.target().then(($target) => {
-            $target[0].textContent = "An updated string";
-          });
+      cy.visitMock({
+        bodyContents:
+          '<input data-testid="target" value="Lorem ipsum dolor" />',
+      });
+      cy.wait(50);
 
-          const start = Date.now();
-
-          // this runs before the mutation occurs, ensure it hasn't been replaced yet
-          selectors
-            .target()
-            .contains("An updated string")
-            .then(() => {
-              expect(renderer.renderCount).to.equal(2);
-            });
-
-          // change text again faster than test frequency - No call!
-          selectors.target().then(($target) => {
-            $target[0].textContent = "Lorem ipsum dolor sit";
-          });
-
-          // use cypress inherent waits to wait for the mutation - Call 3
-          selectors
-            .target()
-            .contains("Lorem sit dolor sit")
-            .then(() => {
-              expect(renderer.renderCount).to.equal(3);
-
-              const end = Date.now();
-              const total = end - start;
-
-              expect(total).greaterThan(testFrequency);
-            });
-        });
+      cy.document().then(($doc) => {
+        new Renderer(browser, $doc.documentElement);
+        selectors.target().should("have.value", "Lorem sit dolor");
+      });
     });
-  });
 
-  it("does not use user frequency preferences when feature is disabled", () => {
-    const testFrequency = 200;
+    it("replaces 'contenteditable' elements on page load when the preference is active", () => {
+      browser.storage.sync.set({
+        matcher__1234: {
+          active: true,
+          identifier: "1234",
+          queries: ["ipsum"],
+          queryPatterns: [],
+          replacement: "sit",
+        },
+        preferences: defaultPreferences,
+      });
 
-    const newRenderRate: RenderRate = {
-      active: false,
-      frequency: testFrequency,
-    };
+      cy.visitMock({
+        bodyContents:
+          '<div data-testid="target" contenteditable>Lorem ipsum dolor</div>',
+      });
+      cy.wait(50);
 
-    cy.document().then(($doc) => {
-      const renderer = new Renderer(browser, $doc.documentElement);
+      cy.document().then(($doc) => {
+        new Renderer(browser, $doc.documentElement);
+        selectors.target().should("have.text", "Lorem sit dolor");
+      });
+    });
 
-      // updating storage renders content immediately - Call 1
-      browser.storage.sync
-        .set({
-          renderRate: newRenderRate,
-        })
-        .then(() => {
-          // change the target element's text to trigger a mutation observer event - Call 2
-          selectors.target().then(($target) => {
-            $target[0].textContent = "An updated string";
-          });
+    it("does not replace text inputs on page load when the preference is active and the mode is not 'real-time'", () => {
+      browser.storage.sync.set({
+        matcher__1234: {
+          active: true,
+          identifier: "1234",
+          queries: ["ipsum"],
+          queryPatterns: [],
+          replacement: "sit",
+        },
+        preferences: {
+          ...defaultPreferences,
+          inputReplacement: {
+            active: true,
+            mode: "on-demand",
+          },
+        },
+      });
 
-          const start = Date.now();
+      cy.visitMock({
+        bodyContents:
+          '<input data-testid="target" value="Lorem ipsum dolor" />',
+      });
+      cy.wait(50);
 
-          // this runs before the mutation occurs, ensure it hasn't been replaced yet
-          selectors
-            .target()
-            .contains("An updated string")
-            .then(() => {
-              expect(renderer.renderCount).to.equal(2);
-            });
+      cy.document().then(($doc) => {
+        new Renderer(browser, $doc.documentElement);
 
-          // wait the default amount of time plus a little
-          cy.wait(DEFAULT_RENDER_RATE_MS + 10);
+        cy.wait(50);
+        selectors.target().should("have.value", "Lorem ipsum dolor");
+      });
+    });
 
-          // change text again faster than test frequency - Call 3
-          selectors.target().then(($target) => {
-            $target[0].textContent = "Lorem ipsum dolor sit";
-          });
+    it("does not replace text inputs on page load when the preference is not active", () => {
+      browser.storage.sync.set({
+        matcher__1234: {
+          active: true,
+          identifier: "1234",
+          queries: ["ipsum"],
+          queryPatterns: [],
+          replacement: "sit",
+        },
+        preferences: {
+          ...defaultPreferences,
+          inputReplacement: {
+            active: false,
+            mode: "real-time",
+          },
+        },
+      });
 
-          // use cypress inherent waits to wait for the mutation - Call 4
-          selectors
-            .target()
-            .contains("Lorem sit dolor sit")
-            .then(() => {
-              expect(renderer.renderCount).to.equal(4);
+      cy.visitMock({
+        bodyContents:
+          '<input data-testid="target" value="Lorem ipsum dolor" />',
+      });
+      cy.wait(50);
 
-              const end = Date.now();
-              const total = end - start;
+      cy.document().then(($doc) => {
+        new Renderer(browser, $doc.documentElement);
 
-              expect(total).lessThan(testFrequency);
-            });
-        });
+        cy.wait(50);
+        selectors.target().should("have.value", "Lorem ipsum dolor");
+      });
+    });
+
+    it("does not replace 'contenteditable' elements on page load when the preference is not active", () => {
+      browser.storage.sync.set({
+        matcher__1234: {
+          active: true,
+          identifier: "1234",
+          queries: ["ipsum"],
+          queryPatterns: [],
+          replacement: "sit",
+        },
+        preferences: {
+          ...defaultPreferences,
+          inputReplacement: {
+            active: false,
+            mode: "real-time",
+          },
+        },
+      });
+
+      cy.visitMock({
+        bodyContents:
+          '<div data-testid="target" contenteditable>Lorem ipsum dolor</div>',
+      });
+      cy.wait(50);
+
+      cy.document().then(($doc) => {
+        new Renderer(browser, $doc.documentElement);
+
+        cy.wait(50);
+        selectors.target().should("have.text", "Lorem ipsum dolor");
+      });
     });
   });
 });

--- a/packages/shared/cypress/e2e/replace/lib/index.ts
+++ b/packages/shared/cypress/e2e/replace/lib/index.ts
@@ -22,6 +22,6 @@ export function searchAndReplace(
       replacement,
       useGlobalReplacementStyle: DEFAULT_USE_GLOBAL_REPLACEMENT_STYLE,
     },
-    replacementStyle
+    { replacementStyle }
   );
 }

--- a/packages/shared/cypress/e2e/replace/lib/index.ts
+++ b/packages/shared/cypress/e2e/replace/lib/index.ts
@@ -1,4 +1,8 @@
-import { findText, replaceText } from "@worm/shared/src/replace";
+import {
+  findText,
+  replaceText,
+  ReplaceTextOptions,
+} from "@worm/shared/src/replace";
 import { DEFAULT_USE_GLOBAL_REPLACEMENT_STYLE } from "@worm/shared/src/replace/lib/style";
 import { QueryPattern, ReplacementStyle } from "@worm/types/src/replace";
 
@@ -10,7 +14,7 @@ export function searchAndReplace(
   query: string,
   queryPatterns: QueryPattern[],
   replacement: string,
-  replacementStyle?: ReplacementStyle
+  options: ReplaceTextOptions
 ) {
   const results = findText(element, query, queryPatterns);
 
@@ -22,6 +26,6 @@ export function searchAndReplace(
       replacement,
       useGlobalReplacementStyle: DEFAULT_USE_GLOBAL_REPLACEMENT_STYLE,
     },
-    { replacementStyle }
+    options
   );
 }

--- a/packages/shared/cypress/e2e/replacement-style.cy.ts
+++ b/packages/shared/cypress/e2e/replacement-style.cy.ts
@@ -23,17 +23,17 @@ function generateReplacementStyle(
 
 describe("replacement style", () => {
   it("does not apply styles when feature is disabled", () => {
-    const testStyle = generateReplacementStyle({ active: false });
+    const replacementStyle = generateReplacementStyle({ active: false });
 
     cy.visitMock({
-      styleContents: getStylesheet(testStyle).textContent?.toString(),
+      styleContents: getStylesheet(replacementStyle).textContent?.toString(),
       targetContents: "Lorem ipsum dolor",
     });
 
     s.target().then(($element) => {
       const target = $element.get(0);
 
-      searchAndReplace(target, "ipsum", [], "sit", testStyle);
+      searchAndReplace(target, "ipsum", [], "sit", { replacementStyle });
       cy.wrap(target).within(() => {
         s.replacedText()
           .invoke("css", "background-color")
@@ -52,17 +52,17 @@ describe("replacement style", () => {
   });
 
   it("applies styles when feature is enabled with default values", () => {
-    const testStyle = generateReplacementStyle();
+    const replacementStyle = generateReplacementStyle();
 
     cy.visitMock({
-      styleContents: getStylesheet(testStyle).textContent?.toString(),
+      styleContents: getStylesheet(replacementStyle).textContent?.toString(),
       targetContents: "Lorem ipsum dolor",
     });
 
     s.target().then(($element) => {
       const target = $element.get(0);
 
-      searchAndReplace(target, "ipsum", [], "sit", testStyle);
+      searchAndReplace(target, "ipsum", [], "sit", { replacementStyle });
       cy.wrap(target).within(() => {
         s.replacedText()
           .invoke("css", "background-color")
@@ -81,7 +81,7 @@ describe("replacement style", () => {
   });
 
   it("applies styles when feature is enabled with custom values", () => {
-    const testStyle = generateReplacementStyle({
+    const replacementStyle = generateReplacementStyle({
       backgroundColor: "red",
       color: "blue",
       options: [
@@ -95,14 +95,14 @@ describe("replacement style", () => {
     });
 
     cy.visitMock({
-      styleContents: getStylesheet(testStyle).textContent?.toString(),
+      styleContents: getStylesheet(replacementStyle).textContent?.toString(),
       targetContents: "Lorem ipsum dolor",
     });
 
     s.target().then(($element) => {
       const target = $element.get(0);
 
-      searchAndReplace(target, "ipsum", [], "sit", testStyle);
+      searchAndReplace(target, "ipsum", [], "sit", { replacementStyle });
       cy.wrap(target).within(() => {
         s.replacedText()
           .invoke("css", "background-color")

--- a/packages/shared/src/browser/render.ts
+++ b/packages/shared/src/browser/render.ts
@@ -130,6 +130,56 @@ export class Renderer {
     this.mutationObserver.observe(this.observedElement, this.OBSERVE_PARAMS);
   }
 
+  private getRenderedMatchers = (): Matcher[] | undefined => {
+    if (!this.renderCache.storage.value) {
+      return;
+    }
+
+    const {
+      storage: {
+        value: syncStorage,
+        value: { matchers = [], ruleGroups },
+      },
+    } = this.renderCache;
+
+    if (!this.isReplaceAllowed()) {
+      return;
+    }
+
+    let renderedMatchers = [...matchers];
+
+    if (ruleGroups?.active) {
+      const matcherGroups = getMatcherGroups(syncStorage);
+
+      if (matcherGroups !== undefined) {
+        const activeGroups = Object.values(matcherGroups).filter(
+          (group) => group.active
+        );
+        const groupedMatchers = new Set(
+          activeGroups.map((group) => [...(group.matchers ?? [])]).flat()
+        );
+
+        if (groupedMatchers.size > 0 || activeGroups.length > 0) {
+          renderedMatchers = renderedMatchers.filter((matcher) =>
+            groupedMatchers.has(matcher.identifier)
+          );
+        }
+      }
+    }
+
+    if (renderedMatchers.length < 1) return;
+
+    return renderedMatchers;
+  };
+
+  private isInputReplaceAllowed(): boolean {
+    return (
+      this.isReplaceAllowed() &&
+      this.renderCache.storage.value?.preferences?.inputReplacement?.active ===
+        true
+    );
+  }
+
   private isReplaceAllowed(): boolean {
     if (!this.renderCache.storage.value) {
       return false;
@@ -148,17 +198,16 @@ export class Renderer {
   }
 
   public replaceInputElements() {
-    if (!this.isReplaceAllowed()) {
+    const renderedMatchers = this.getRenderedMatchers();
+
+    if (!this.isInputReplaceAllowed() || !renderedMatchers) {
       return;
     }
 
-    replaceAllInputElements(
-      this.renderCache.storage.value?.matchers ?? [],
-      this.observedElement
-    );
+    replaceAllInputElements(renderedMatchers, this.observedElement);
   }
 
-  public renderContent = async (message = "") => {
+  public renderContent = async (_message = "") => {
     const now = new Date().getTime();
 
     if (now > this.renderCache.storage.expires) {
@@ -208,8 +257,7 @@ export class Renderer {
 
     const {
       storage: {
-        value: syncStorage,
-        value: { matchers = [], replacementStyle, ruleGroups },
+        value: { preferences, replacementStyle },
       },
     } = this.renderCache;
 
@@ -217,33 +265,24 @@ export class Renderer {
       return;
     }
 
-    let renderedMatchers = [...matchers];
-
-    if (ruleGroups?.active) {
-      const matcherGroups = getMatcherGroups(syncStorage);
-
-      if (matcherGroups !== undefined) {
-        const activeGroups = Object.values(matcherGroups).filter(
-          (group) => group.active
-        );
-        const groupedMatchers = new Set(
-          activeGroups.map((group) => [...(group.matchers ?? [])]).flat()
-        );
-
-        if (groupedMatchers.size > 0 || activeGroups.length > 0) {
-          renderedMatchers = renderedMatchers.filter((matcher) =>
-            groupedMatchers.has(matcher.identifier)
-          );
-        }
-      }
-    }
-
-    if (renderedMatchers.length < 1) return;
+    const renderedMatchers = this.getRenderedMatchers();
+    if (!renderedMatchers) return;
 
     this.mutationObserver?.disconnect();
 
     try {
-      replaceAll(renderedMatchers, replacementStyle, this.observedElement);
+      replaceAll(
+        renderedMatchers,
+        { preferences, replacementStyle },
+        this.observedElement
+      );
+
+      if (
+        this.renderCache.storage.value.preferences?.inputReplacement.mode ===
+        "real-time"
+      ) {
+        this.replaceInputElements();
+      }
     } finally {
       this.renderCount++;
       this.mutationObserver?.observe(this.observedElement, this.OBSERVE_PARAMS);

--- a/packages/shared/src/browser/render.ts
+++ b/packages/shared/src/browser/render.ts
@@ -5,7 +5,11 @@ import { SyncStorage } from "@worm/types/src/storage";
 
 import { debounce } from "../debounce";
 import { isDomainAllowed } from "../domains";
-import { replaceAll, replaceAllInputElements } from "../replace";
+import {
+  replaceAll,
+  replaceAllInputElements,
+  ReplaceTextOptions,
+} from "../replace";
 import {
   DEFAULT_RENDER_RATE,
   DEFAULT_RENDER_RATE_MS,
@@ -204,7 +208,16 @@ export class Renderer {
       return;
     }
 
-    replaceAllInputElements(renderedMatchers, this.observedElement);
+    const replaceOptions: ReplaceTextOptions = {
+      preferences: this.renderCache.storage.value?.preferences,
+      replacementStyle: this.renderCache.storage.value?.replacementStyle,
+    };
+
+    replaceAllInputElements(
+      renderedMatchers,
+      this.observedElement,
+      replaceOptions
+    );
   }
 
   public renderContent = async (_message = "") => {
@@ -246,6 +259,21 @@ export class Renderer {
             expires: renderCacheExpires,
             value: newStyleElement,
           };
+        }
+
+        const iframes = document.querySelectorAll("iframe");
+        for (const iframe of iframes) {
+          const iframeDocument =
+            iframe.contentDocument ?? iframe.contentWindow?.document;
+          if (
+            !iframeDocument?.head ||
+            iframeDocument.head.querySelector(`#${STYLE_ELEMENT_ID}`)
+          ) {
+            continue;
+          }
+
+          const iframeStyleElement = getStylesheet(storage.replacementStyle);
+          iframeDocument.head.appendChild(iframeStyleElement);
         }
       }
     }

--- a/packages/shared/src/replace/find-text.ts
+++ b/packages/shared/src/replace/find-text.ts
@@ -3,6 +3,7 @@ import { QueryPattern } from "@worm/types/src/replace";
 import { CONTENTS_PROPERTY } from "./lib";
 import { nodeNameBlocklist } from "./lib/dom";
 import { getRegexFlags, patternRegex } from "./lib/regex";
+import { ReplaceTextOptions } from "./replace-text";
 
 /**
  * Recursively crawls an element in search of a given query and returns a list
@@ -12,6 +13,7 @@ export function findText(
   element: HTMLElement,
   query: string,
   queryPatterns: QueryPattern[],
+  options: ReplaceTextOptions = {},
   found: Text[] = []
 ) {
   const elementContents = String(element[CONTENTS_PROPERTY]);
@@ -49,7 +51,7 @@ export function findText(
     const childElements = Array.from(element.childNodes) as HTMLElement[];
 
     for (const child of childElements) {
-      findText(child, query, queryPatterns, found);
+      findText(child, query, queryPatterns, options, found);
     }
   }
 
@@ -59,7 +61,11 @@ export function findText(
     !nodeNameBlocklist.has(
       String(element.parentNode?.nodeName.toLowerCase())
     ) &&
-    !element.parentElement?.isContentEditable
+    (!element.parentElement?.isContentEditable ||
+      !!(
+        options.preferences?.inputReplacement.active &&
+        options.preferences.inputReplacement.mode === "real-time"
+      ))
   ) {
     found.push(element as unknown as Text);
   }

--- a/packages/shared/src/replace/find-text.ts
+++ b/packages/shared/src/replace/find-text.ts
@@ -62,10 +62,9 @@ export function findText(
       String(element.parentNode?.nodeName.toLowerCase())
     ) &&
     (!element.parentElement?.isContentEditable ||
-      !!(
-        options.preferences?.inputReplacement?.active &&
-        options.preferences.inputReplacement.mode === "real-time"
-      ))
+      options.includeEditableContent ||
+      (options.preferences?.inputReplacement?.active &&
+        options.preferences.inputReplacement.mode === "real-time"))
   ) {
     found.push(element as unknown as Text);
   }

--- a/packages/shared/src/replace/find-text.ts
+++ b/packages/shared/src/replace/find-text.ts
@@ -63,7 +63,7 @@ export function findText(
     ) &&
     (!element.parentElement?.isContentEditable ||
       !!(
-        options.preferences?.inputReplacement.active &&
+        options.preferences?.inputReplacement?.active &&
         options.preferences.inputReplacement.mode === "real-time"
       ))
   ) {

--- a/packages/shared/src/replace/index.ts
+++ b/packages/shared/src/replace/index.ts
@@ -54,6 +54,23 @@ export function replaceAll(
   }
 }
 
+export function replaceEditable(
+  matchers: Matcher[],
+  options: ReplaceTextOptions = {},
+  element: HTMLElement
+) {
+  for (const matcher of matchers) {
+    if (matcher.active !== true) continue;
+
+    for (const query of matcher.queries) {
+      searchAndReplace(element, query, matcher, {
+        ...options,
+        includeEditableContent: true,
+      });
+    }
+  }
+}
+
 export * from "./find-text";
 export * from "./lib";
 export * from "./replace-input";

--- a/packages/shared/src/replace/index.ts
+++ b/packages/shared/src/replace/index.ts
@@ -1,30 +1,30 @@
-import { ReplacementStyle } from "@worm/types/src/replace";
 import { Matcher } from "@worm/types/src/rules";
 
 import { logDebug } from "../logging";
 
 import { findText } from "./find-text";
-import { replaceText } from "./replace-text";
+import { replaceText, ReplaceTextOptions } from "./replace-text";
 
 function searchAndReplace(
   element: HTMLElement,
   query: string,
   matcher: Matcher,
-  replacementStyle: ReplacementStyle | undefined
+  options: ReplaceTextOptions = {}
 ) {
   const { queryPatterns } = matcher;
-  const searchResults = findText(element, query, queryPatterns, []) || [];
+  const searchResults =
+    findText(element, query, queryPatterns, options, []) || [];
 
   for (let position = 0; position < searchResults.length; position++) {
     const textElement = searchResults[position];
 
-    replaceText(textElement, query, matcher, replacementStyle, position);
+    replaceText(textElement, query, matcher, options, position);
   }
 }
 
 export function replaceAll(
   matchers: Matcher[],
-  replacementStyle: ReplacementStyle | undefined,
+  options: ReplaceTextOptions = {},
   startDocument: Document | HTMLElement = document
 ) {
   const body = startDocument.querySelector("body");
@@ -42,12 +42,12 @@ export function replaceAll(
 
     for (const query of matcher.queries) {
       if (body) {
-        searchAndReplace(body, query, matcher, replacementStyle);
+        searchAndReplace(body, query, matcher, options);
       }
 
       if (head) {
         for (const title of Array.from(head.querySelectorAll("title"))) {
-          searchAndReplace(title, query, matcher, replacementStyle);
+          searchAndReplace(title, query, matcher, options);
         }
       }
     }

--- a/packages/shared/src/replace/lib/input-replace.ts
+++ b/packages/shared/src/replace/lib/input-replace.ts
@@ -1,0 +1,6 @@
+import { InputReplacement } from "@worm/types/src/replace";
+
+export const DEFAULT_INPUT_REPLACE: InputReplacement = {
+  active: false,
+  mode: "on-demand",
+};

--- a/packages/shared/src/replace/replace-input.ts
+++ b/packages/shared/src/replace/replace-input.ts
@@ -1,5 +1,6 @@
 import { Matcher } from "@worm/types/src/rules";
 
+import { replaceEditable, ReplaceTextOptions } from ".";
 import { isReplacementEmpty, getSortedQueryPatterns, hashValue } from "./lib";
 import { getRegexFlags, patternRegex } from "./lib/regex";
 
@@ -62,32 +63,6 @@ function applyQueryReplacement(
   return result;
 }
 
-function replaceHTMLValue(element: HTMLElement, matchers: Matcher[]) {
-  const valueProperty: keyof Pick<HTMLElement, "innerHTML"> = "innerHTML";
-  const lastReplaced = (element as HTMLElement).dataset[LAST_VALUE_DATA_KEY];
-
-  if (
-    lastReplaced !== undefined &&
-    lastReplaced === hashValue(element[valueProperty])
-  )
-    return;
-
-  let value = element[valueProperty];
-
-  for (const matcher of matchers) {
-    if (matcher.active !== true) continue;
-
-    for (const query of matcher.queries) {
-      value = applyQueryReplacement(value, query, matcher);
-    }
-  }
-
-  if (value === element[valueProperty]) return;
-
-  element[valueProperty] = value;
-  element.dataset[LAST_VALUE_DATA_KEY] = hashValue(value);
-}
-
 function replaceInputValue(
   element: HTMLInputElement | HTMLTextAreaElement,
   matchers: Matcher[]
@@ -119,7 +94,8 @@ function replaceInputValue(
 
 export function replaceAllInputElements(
   matchers: Matcher[],
-  root: Document | HTMLElement = document
+  root: Document | HTMLElement = document,
+  options: ReplaceTextOptions = {}
 ) {
   const activeMatchers = matchers.filter((m) => m.active);
   if (activeMatchers.length < 1) return;
@@ -139,7 +115,7 @@ export function replaceAllInputElements(
   );
 
   for (const el of editableHTMLElements) {
-    replaceHTMLValue(el, activeMatchers);
+    replaceEditable(matchers, options, el);
   }
 
   const iframes = Array.from(
@@ -156,7 +132,7 @@ export function replaceAllInputElements(
       const isBodyEditable = doc.body?.isContentEditable === true;
 
       if (isDesignMode || isBodyEditable) {
-        replaceHTMLValue(doc.body, activeMatchers);
+        replaceEditable(matchers, options, doc.body);
       }
     } catch {
       // cross-origin iframes will throw, skip silently

--- a/packages/shared/src/replace/replace-text.ts
+++ b/packages/shared/src/replace/replace-text.ts
@@ -11,6 +11,7 @@ import { getReplacementHTML, replaceTextNode } from "./lib/dom";
 import { getRegexFlags, patternRegex, regExpReplace } from "./lib/regex";
 
 export type ReplaceTextOptions = {
+  includeEditableContent?: boolean;
   preferences?: Partial<SyncStorage["preferences"]>;
   replacementStyle?: SyncStorage["replacementStyle"];
 };

--- a/packages/shared/src/replace/replace-text.ts
+++ b/packages/shared/src/replace/replace-text.ts
@@ -11,10 +11,10 @@ import {
 import { getReplacementHTML, replaceTextNode } from "./lib/dom";
 import { getRegexFlags, patternRegex, regExpReplace } from "./lib/regex";
 
-export type ReplaceTextOptions = Pick<
-  SyncStorage,
-  "preferences" | "replacementStyle"
->;
+export type ReplaceTextOptions = {
+  preferences?: Partial<SyncStorage["preferences"]>;
+  replacementStyle?: SyncStorage["replacementStyle"];
+};
 
 export function replaceText(
   element: Text | undefined,

--- a/packages/shared/src/replace/replace-text.ts
+++ b/packages/shared/src/replace/replace-text.ts
@@ -1,5 +1,6 @@
 import { ReplacementStyle } from "@worm/types/src/replace";
 import { MatcherReplaceProps } from "@worm/types/src/rules";
+import { SyncStorage } from "@worm/types/src/storage";
 
 import {
   CONTENTS_PROPERTY,
@@ -10,11 +11,16 @@ import {
 import { getReplacementHTML, replaceTextNode } from "./lib/dom";
 import { getRegexFlags, patternRegex, regExpReplace } from "./lib/regex";
 
+export type ReplaceTextOptions = Pick<
+  SyncStorage,
+  "preferences" | "replacementStyle"
+>;
+
 export function replaceText(
   element: Text | undefined,
   query: string,
   matcher: MatcherReplaceProps,
-  replacementStyle: ReplacementStyle | undefined,
+  options: ReplaceTextOptions = {},
   startPosition: number = 0
 ) {
   const { queryPatterns, replacement, useGlobalReplacementStyle } = matcher;
@@ -58,7 +64,7 @@ export function replaceText(
   if (!queryPatterns || queryPatterns.length < 1) {
     // proceed with default
     const replaced = elementContents.replace(patternRegex.default(query), () =>
-      getReplacementHTML(element, query, matcher, replacementStyle)
+      getReplacementHTML(element, query, matcher, options.replacementStyle)
     );
 
     replaceTextNode(element, replaced);
@@ -74,7 +80,12 @@ export function replaceText(
           const searchValue = patternRegex[pattern](query);
 
           replaced = elementContents.replace(searchValue, () =>
-            getReplacementHTML(element, query, matcher, replacementStyle)
+            getReplacementHTML(
+              element,
+              query,
+              matcher,
+              options.replacementStyle
+            )
           );
           break;
         }
@@ -86,7 +97,7 @@ export function replaceText(
 
           replaced = elementContents.replace(
             searchValue,
-            regExpReplace(element, query, matcher, replacementStyle)
+            regExpReplace(element, query, matcher, options.replacementStyle)
           );
           break;
         }
@@ -98,7 +109,12 @@ export function replaceText(
 
           replaced = elementContents
             .replace(searchValue, () =>
-              getReplacementHTML(element, query, matcher, replacementStyle)
+              getReplacementHTML(
+                element,
+                query,
+                matcher,
+                options.replacementStyle
+              )
             )
             .replace(/\s\s+/g, "");
           break;

--- a/packages/shared/src/replace/replace-text.ts
+++ b/packages/shared/src/replace/replace-text.ts
@@ -1,4 +1,3 @@
-import { ReplacementStyle } from "@worm/types/src/replace";
 import { MatcherReplaceProps } from "@worm/types/src/rules";
 import { SyncStorage } from "@worm/types/src/storage";
 
@@ -23,7 +22,7 @@ export function replaceText(
   options: ReplaceTextOptions = {},
   startPosition: number = 0
 ) {
-  const { queryPatterns, replacement, useGlobalReplacementStyle } = matcher;
+  const { queryPatterns, replacement } = matcher;
 
   if (!element || isReplacementEmpty(replacement)) return;
 

--- a/packages/shared/src/storage/database-migrations/index.ts
+++ b/packages/shared/src/storage/database-migrations/index.ts
@@ -15,6 +15,7 @@ import {
 import { STORAGE_MATCHER_PREFIX } from "../../browser";
 import { DEFAULT_COLOR_MODE } from "../../color";
 import { logDebug } from "../../logging";
+import { DEFAULT_INPUT_REPLACE } from "../../replace/lib/input-replace";
 import { DEFAULT_RULE_GROUPS } from "../../replace/lib/groups";
 import { DEFAULT_RENDER_RATE } from "../../replace/lib/render";
 import { DEFAULT_RULE_SYNC } from "../../replace/lib/rule-sync";
@@ -170,6 +171,21 @@ export const MIGRATIONS: StrictMigrations = {
         await localStorageProvider.set(localUpdate);
 
         return storage;
+      },
+    },
+    6: {
+      /**
+       * **1.6.0** - Input replacement options
+       *
+       * Options to control how input replacements are applied.
+       */
+      0: async (storage) => {
+        const newPreferences = Object.assign({}, storage.preferences);
+        newPreferences.inputReplacement = DEFAULT_INPUT_REPLACE;
+
+        const merged = merge(storage, { preferences: newPreferences });
+
+        return merged;
       },
     },
   },

--- a/packages/shared/src/storage/index.ts
+++ b/packages/shared/src/storage/index.ts
@@ -9,7 +9,7 @@ export const BASELINE_STORAGE_VERSION: StorageVersion = "1.0.0";
 /**
  * The storage version currently in use.
  */
-export const CURRENT_STORAGE_VERSION: StorageVersion = "1.5.0";
+export const CURRENT_STORAGE_VERSION: StorageVersion = "1.6.0";
 
 export * from "./api";
 export * from "./migrations";

--- a/packages/testing/src/test-browser.ts
+++ b/packages/testing/src/test-browser.ts
@@ -1,3 +1,4 @@
+import { DEFAULT_INPUT_REPLACE } from "@worm/shared/src/replace/lib/input-replace";
 import { DEFAULT_RENDER_RATE } from "@worm/shared/src/replace/lib/render";
 import { DEFAULT_RULE_SYNC } from "@worm/shared/src/replace/lib/rule-sync";
 import { DEFAULT_REPLACEMENT_STYLE } from "@worm/shared/src/replace/lib/style";
@@ -35,10 +36,7 @@ const mockSyncStorage: Record<string, any> = {
       field: "replacement",
       matcher: "",
     },
-    inputReplacement: {
-      active: false,
-      mode: "on-demand",
-    },
+    inputReplacement: DEFAULT_INPUT_REPLACE,
   },
   renderRate: DEFAULT_RENDER_RATE,
   replacementStyle: DEFAULT_REPLACEMENT_STYLE,

--- a/packages/testing/src/test-browser.ts
+++ b/packages/testing/src/test-browser.ts
@@ -35,6 +35,10 @@ const mockSyncStorage: Record<string, any> = {
       field: "replacement",
       matcher: "",
     },
+    inputReplacement: {
+      active: false,
+      mode: "on-demand",
+    },
   },
   renderRate: DEFAULT_RENDER_RATE,
   replacementStyle: DEFAULT_REPLACEMENT_STYLE,

--- a/packages/types/src/replace.ts
+++ b/packages/types/src/replace.ts
@@ -1,5 +1,12 @@
 const queryPatterns = ["case", "default", "regex", "wholeWord"] as const;
 
+export type InputReplacement = {
+  active: boolean;
+  mode: InputReplacementMode;
+};
+
+export type InputReplacementMode = "on-demand" | "real-time";
+
 /**
  * PCRE case modes for use in regex replacements.
  */

--- a/packages/types/src/storage.ts
+++ b/packages/types/src/storage.ts
@@ -2,7 +2,7 @@ import { Storage as BrowserStorage } from "webextension-polyfill";
 import { z } from "zod";
 
 import { DomainEffect, ExportLink, PopupTab } from "./popup";
-import { ReplacementStyle, RuleGroups } from "./replace";
+import { InputReplacement, ReplacementStyle, RuleGroups } from "./replace";
 import { Matcher, RenderRate, RuleSync } from "./rules";
 
 export const schemaVersions = [1] as const;
@@ -14,6 +14,7 @@ export const storageVersions = [
   "1.3.0",
   "1.4.0",
   "1.5.0",
+  "1.6.0",
 ] as const;
 
 export type ColorMode = "dark" | "light" | "system";
@@ -102,4 +103,5 @@ export type SyncStoragePreferences = {
     field: keyof Pick<Matcher, "queries" | "replacement">;
     matcher: Matcher["identifier"];
   };
+  inputReplacement: InputReplacement;
 };


### PR DESCRIPTION
## Major

- Re-introduces automatic input replacements behind an opt-in toggle on the Options page - Resolves #118

## Assets

|Options page|Confirm dialog|
|-|-|
|<img width="525" height="235" alt="Screenshot 2026-04-05 at 8 41 00 AM" src="https://github.com/user-attachments/assets/62af95dd-d23c-4930-9eb2-521d72eb1460" />|<img width="520" height="461" alt="Screenshot 2026-04-05 at 8 41 13 AM" src="https://github.com/user-attachments/assets/7e250eb9-1aee-433e-a054-ab2dfa7e01ec" />|
